### PR TITLE
mingw64-git: Add short `SHA1` to the version

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -4,7 +4,8 @@
 _realname=git
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.3.1
+tag=2.3.1
+pkgver=2.3.1.3cd528c
 pkgrel=1
 pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('i686' 'x86_64')
@@ -27,9 +28,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "perl-Net-SMTP-SSL"
          "perl-TermReadKey")
 
-source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$pkgver.windows.$pkgrel")
+source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$tag.windows.$pkgrel")
 
 md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/git"
+  printf "%s.%s" "${tag}" "$(git rev-parse --short HEAD)"
+}
 
 build() {
   export PYTHON_PATH=/usr/bin/python2


### PR DESCRIPTION
When generating the `git` package for the `net-installer` to install the
*Git for Windows SDK* it should be best practice to append the short
`SHA1` of the current `HEAD` commit.

With this feature future developer can spot right on which development
state the current package was built on.

Signed-off-by: nalla <nalla@hamal.uberspace.de>