### PR TITLE
asciidoctor: bundle requirements to build git doc

### DIFF
--- a/mingw-w64-asciidoctor-extensions/0001-man-inline-macro-enable-linkgit-syntax.patch
+++ b/mingw-w64-asciidoctor-extensions/0001-man-inline-macro-enable-linkgit-syntax.patch
@@ -1,0 +1,30 @@
+From 188e7c217a942309277c3171de2b863f27453f9a Mon Sep 17 00:00:00 2001
+From: nalla <nalla@hamal.uberspace.de>
+Date: Tue, 14 Apr 2015 11:42:10 +0100
+Subject: [PATCH] man-inline-macro: enable `:linkgit` syntax
+
+For building the documentation with `asciidoctor` the provided
+`man-inline-macro` has to be patched to include the `:linkgit` syntax.
+
+Signed-off-by: nalla <nalla@hamal.uberspace.de>
+---
+ lib/man-inline-macro.rb | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/man-inline-macro.rb b/lib/man-inline-macro.rb
+index 08549e9..96718be 100644
+--- a/lib/man-inline-macro.rb
++++ b/lib/man-inline-macro.rb
+@@ -1,7 +1,7 @@
+ RUBY_ENGINE == 'opal' ? (require 'man-inline-macro/extension') : (require_relative 'man-inline-macro/extension')
+ 
+ Extensions.register :uri_schemes do
+-  inline_macro ManInlineMacro
++  #inline_macro ManInlineMacro
+   # Use the following instead for the git man pages
+-  #inline_macro ManInlineMacro, :linkgit
++  inline_macro ManInlineMacro, :linkgit
+ end
+-- 
+2.3.5.windows.8
+

--- a/mingw-w64-asciidoctor-extensions/PKGBUILD
+++ b/mingw-w64-asciidoctor-extensions/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: nalla <nalla@hamal.uberspace.de>
+
+_realname=asciidoctor-extensions
+
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=79.4c6d08e
+pkgrel=1
+pkgdesc="This package installs asciidoctor plus extensions."
+url="https://github.com/asciidoctor/asciidoctor"
+arch=('i686' 'x86_64')
+license=('GPL2')
+install="${_realname}.install"
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-git")
+depends=("${MINGW_PACKAGE_PREFIX}-ruby")
+
+source=("${_realname}"::"git+https://github.com/asciidoctor/asciidoctor-extensions-lab"
+        "0001-man-inline-macro-enable-linkgit-syntax.patch")
+
+md5sums=('SKIP'
+         '1c6e5a44d07eb92224269ca5964f79fd')
+
+pkgver() {
+  cd "$srcdir/${_realname}"
+  printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+case "$CARCH" in
+i686)
+  LIBDIR="/mingw32/lib/${_realname}"
+  ;;
+x86_64)
+  LIBDIR="/mingw64/lib/${_realname}"
+  ;;
+esac
+
+build() {
+  cd "$srcdir/${_realname}"
+  git am "$srcdir/0001-man-inline-macro-enable-linkgit-syntax.patch"
+}
+
+package() {
+  install -d -m755 "$pkgdir$LIBDIR"
+  install -m755 "$srcdir/${_realname}"/lib/*.rb "$pkgdir$LIBDIR"
+  
+  for directory in `find $srcdir/${_realname}/lib/* -prune -type d`
+  do
+    extension="${directory##$srcdir/${_realname}/lib/}"
+
+    install -d -m755 "$pkgdir$LIBDIR/$extension"
+    install -m755 "$srcdir/${_realname}/lib/$extension"/* "$pkgdir$LIBDIR/$extension"
+  done
+}

--- a/mingw-w64-asciidoctor-extensions/asciidoctor-extensions.install
+++ b/mingw-w64-asciidoctor-extensions/asciidoctor-extensions.install
@@ -1,0 +1,4 @@
+pre_install() {
+  gem install asciidoctor
+}
+


### PR DESCRIPTION
This new package will install `asciidoctor` in the `pre_install` function.
The already available `man-inline-macro` is then patched to support the
`:linkgit` syntax and then installed in the appropiate lib directory.

Signed-off-by: nalla <nalla@hamal.uberspace.de>