### PR TITLE
[FIXED git-for-windows/git/issues/92] enable curl sspi ...

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.41.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -77,6 +77,7 @@ build() {
     --without-random \
     --enable-static \
     --enable-shared \
+    --enable-sspi \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
   make


### PR DESCRIPTION
... in order to authenticate against SPNEGO hosts

refer to: https://github.com/git-for-windows/git/issues/92