### PR TITLE
Added missing dependencies to PKGBUILD file

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -19,10 +19,12 @@ makedepends=('python2' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
 	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
 
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-ca-certificates"
          "${MINGW_PACKAGE_PREFIX}-expat>=2.0"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-tcl"
+         "${MINGW_PACKAGE_PREFIX}-tk"
          "perl-Error"
          "perl>=5.14.0"
          "perl-Authen-SASL"


### PR DESCRIPTION
This adds `mingw64/mingw-w64-x86_64-ca-certificates` and `mingw64/mingw-w64-x86_64-tk` (for `wish.exe`) as dependencies of the git package to the `PKGBUILD` file.