### PR TITLE
configure path to ssl ca bundle; add ability to work as /usr/bin/git

### DIFF
--- a/mingw-w64-git/0001-msys2-usr-link-hack.patch.in
+++ b/mingw-w64-git/0001-msys2-usr-link-hack.patch.in
@@ -1,0 +1,32 @@
+diff --git a/exec_cmd.c b/exec_cmd.c
+index e85f0fd..a7dce3b 100644
+--- a/exec_cmd.c
++++ b/exec_cmd.c
+@@ -15,8 +15,10 @@ char *system_path(const char *path)
+ #endif
+ 	struct strbuf d = STRBUF_INIT;
+ 
++#ifndef __MINGW32__
+ 	if (is_absolute_path(path))
+ 		return xstrdup(path);
++#endif
+ 
+ #ifdef RUNTIME_PREFIX
+ 	assert(argv0_path);
+@@ -31,5 +33,12 @@ char *system_path(const char *path)
+ 				"but prefix computation failed.  "
+ 				"Using static fallback '%s'.\n", prefix);
+ 	}
++#ifdef __MINGW32__
++	char *slash = strrchr(prefix, '\\');
++	if (slash && !strcmp(slash, "\\usr")) {
++	    char *nprefix = strip_path_suffix(prefix, "usr");
++	    strbuf_addf(&d, "%s/@@PKGPREFIX@@/%s", nprefix, path);
++	} else
++#endif
+ #endif
+ 
+	strbuf_addf(&d, "%s/%s", prefix, path);
+ 	return strbuf_detach(&d, NULL);
+ }
+ 

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -10,7 +10,7 @@ test -z "SKIP_GIT_DOCS" ||
 pkgname="${pkgname[0]}"
 tag=2.4.6.windows.1
 pkgver=2.4.6.1.43f871f
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('any')
 url="http://git-for-windows.github.io/"
@@ -35,9 +35,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "perl-Net-SMTP-SSL"
          "perl-TermReadKey")
 
-source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$tag")
+source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$tag"
+        '0001-msys2-usr-link-hack.patch.in')
 
-md5sums=('SKIP')
+md5sums=('SKIP'
+         'SKIP')
 
 pkgver() {
   cd "$srcdir/git"
@@ -77,6 +79,12 @@ build() {
   # otherwise default to one job at a time
   # for example, PARALLEL_BUILD=-j8
   counter=0
+
+  local edpatch="$srcdir/0001-msys2-usr-link-hack.patch"
+  cp "$srcdir/0001-msys2-usr-link-hack.patch.in" "$edpatch"
+  sed "s%@@PKGPREFIX@@%${MINGW_PREFIX#/}%" -i "$edpatch"
+  patch -p1 -i "$edpatch"
+
   while ! if test -z "$SKIP_GIT_DOCS"
     then
       make "${PARALLEL_BUILD:--j1}" all
@@ -127,6 +135,8 @@ EOF
 }
 
 package_git () {
+  backup=("${MINGW_PREFIX#/}/etc/gitconfig")
+
   export PYTHON_PATH=/usr/bin/python2
   cd "$srcdir"/git
 
@@ -158,6 +168,13 @@ package_git () {
 
   # Install builtins.txt
   install -m644 builtins.txt $pkgdir$SHAREDIR
+
+  # Set path to CA cert bundle in system-wide gitconfig so https works
+  local etcdir="$pkgdir/$PREFIX/etc"
+  mkdir -p "$etcdir"
+  local config_cmd="$pkgdir/$PREFIX/libexec/git-core/git-config"
+  local certpath="$PREFIX/ssl/certs/ca-bundle.crt"
+  "$config_cmd" -f "$etcdir/gitconfig" http.sslCAInfo "$certpath"
 }
 
 package_git-doc-html () {


### PR DESCRIPTION
we do not actually make a link for /usr/bin/git, but the changes in
exec_cmd.c make it possible to install this package and create one and
have things work correctly (without them, lookups using e.g. system_path
won't work right)