### PR TITLE
Include `getopt` in the package build.

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ url="http://git-for-windows.github.io/"
 license=('GPL2')
 
 makedepends=('python2' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
-	'ca-certificates' 'asciidoc' 'xmlto'
+	'ca-certificates' 'asciidoc' 'getopt' 'xmlto'
 	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
 
 depends=("${MINGW_PACKAGE_PREFIX}-curl"


### PR DESCRIPTION
As suggested by @nalla in this PR: https://github.com/git-for-windows/build-extra/pull/68