### PR TITLE
Add the Xpdf package

### DIFF
--- a/mingw-w64-xpdf/PKGBUILD
+++ b/mingw-w64-xpdf/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=xpdf
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=3.04
+pkgrel=1
+pkgdesc="Utilities for PDF files (mingw-w64)"
+arch=('any')
+license=('GPL2+')
+url="http://foolabs.com/xpdf/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-libpng")
+options=('strip')
+source=(${_realname}::"ftp://ftp.foolabs.com/pub/xpdf/xpdf-${pkgver}.tar.gz")
+sha1sums=('b9b1dbb0335742a09d0442c60fd02f4f934618bd')
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+  ../${_realname}-${pkgver}/configure --prefix=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
This package only contains the utilities (pdfimages, pdftotext, etc) but
not the viewer because Xpdf's viewer works only with X11.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>