### PR TITLE
git: fix asciidoctor invocation

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -64,7 +64,7 @@ prepare () {
 	ASCIIDOC_HTML=html5
 	ASCIIDOC_DOCBOOK=docbook45
 	ASCIIDOC_EXTRA="-alitdd=&\#45;&\#45;"
-	ASCIIDOC_CONF="-I$ASCIIDOCTORDIR -rman-inline-macro"
+	ASCIIDOC_CONF=-I"$ASCIIDOCTORDIR" -rman-inline-macro
 	EOF
 }
 


### PR DESCRIPTION
When creating the `config.mak` to tell `make` to use asciidoctor `instead`
of `asciidoc`, lets make sure that we only quote the parts that needs it.
Quoting the full `ASCIIDOCTOR_CONF` variable is leading to a wrong
invocation of the `asciidoctor` command because then the different
asciidoctor options `-I` and `-r` are not being recognized.

This fixes https://github.com/git-for-windows/git/issues/404