### PR TITLE
Add helper script for ssh-pageant integration

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -36,6 +36,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
 source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$tag"
 	'git-for-windows.ico'
 	'start-ssh-agent.cmd'
+	'start-ssh-pageant.cmd'
 	'git-bash.rc'
 	'git-cmd.rc'
 	'git-wrapper.rc'
@@ -45,6 +46,7 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 md5sums=('SKIP'
          '18763e83447859af27f30b316d7e9f64'
          'c9ce5141664cc7f221c06fcb8b4becb5'
+         'fe57499d10c5fd319bce323aac321f71'
          '24892485098f4b47d6d73e09f5a0ad39'
          '0f3fb5d6fb2a591140f11de52745d4a2'
          'b2d7878989a5483705c0da5b92b39e80'
@@ -173,7 +175,8 @@ package_git () {
   # Install Git wrapper into /cmd/
   install -d -m755 $pkgdir/cmd
   install -m755 cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
-	../start-ssh-agent.cmd $pkgdir/cmd
+	../start-ssh-agent.cmd ../start-ssh-pageant.cmd \
+	$pkgdir/cmd
 
   # Install builtins.txt
   install -m644 builtins.txt $pkgdir$SHAREDIR

--- a/mingw-w64-git/start-ssh-pageant.cmd
+++ b/mingw-w64-git/start-ssh-pageant.cmd
@@ -1,0 +1,63 @@
+@REM Do not use "echo off" to not affect any child calls.
+
+@REM The goal of this script is to simplify launching `ssh-pageant` at
+@REM logon, typically by dropping a shortcut into the Startup folder, so
+@REM that Pageant (the PuTTY authentication agent) will always be
+@REM accessible. No attempt is made to load SSH keys, since this is
+@REM normally handled directly by Pageant, and no interactive shell
+@REM will be launched.
+@REM 
+@REM The `ssh-pageant` utility is launched with the `-r` (reuse socket)
+@REM option, to ensure that only a single running incarnation (per user)
+@REM will be required... instead of launching a separate process for
+@REM every interactive Git Bash session. A side effect of this selection
+@REM is that the SSH_AUTH_SOCK environment variable *must* be set prior
+@REM to running this script, with the value specifying a unix-style socket
+@REM path, and needs to be consistent for all git-related processes. The
+@REM easiest way to do this is to set a persistent USER environment
+@REM variable, which (under Windows 7) can be done via Control Panel
+@REM under System / Advanced System Settings. A typical value would look
+@REM similar to:
+@REM
+@REM    SSH_AUTH_SOCK=/tmp/.ssh-pageant-USERNAME
+@REM
+
+@REM Enable extensions, the `verify` call is a trick from the setlocal help
+@VERIFY other 2>nul
+@SETLOCAL EnableDelayedExpansion
+@IF ERRORLEVEL 1 (
+    @ECHO Unable to enable extensions
+    @GOTO failure
+)
+
+@REM Ensure that SSH_AUTH_SOCK is set
+@if "x" == "x%SSH_AUTH_SOCK%" @(
+    @ECHO The SSH_AUTH_SOCK environment variable must be set prior to running this script. >&2
+    @ECHO This is typically configured as a persistent USER variable, using a MSYS2 path for >&2
+    @ECHO the ssh-pageant authentication socket as the value. Something similar to: >&2
+    @ECHO. >&2
+    @ECHO    SSH_AUTH_SOCK=/tmp/.ssh-pageant-%USERNAME% >&2
+    @GOTO failure
+)
+
+@REM Start ssh-pageant if needed by git
+@FOR %%i IN ("git.exe") DO @SET GIT=%%~$PATH:i
+@IF EXIST "%GIT%" @(
+    @REM Get the ssh-pageant executable
+    @FOR %%i IN ("ssh-pageant.exe") DO @SET SSH_PAGEANT=%%~$PATH:i
+    @IF NOT EXIST "%SSH_PAGEANT%" @(
+        @FOR %%s IN ("%GIT%") DO @SET GIT_DIR=%%~dps
+        @FOR %%s IN ("!GIT_DIR!") DO @SET GIT_DIR=!GIT_DIR:~0,-1!
+        @FOR %%s IN ("!GIT_DIR!") DO @SET GIT_ROOT=%%~dps
+        @FOR %%s IN ("!GIT_ROOT!") DO @SET GIT_ROOT=!GIT_ROOT:~0,-1!
+        @FOR /D %%s in ("!GIT_ROOT!\usr\bin\ssh-pageant.exe") DO @SET SSH_PAGEANT=%%~s
+        @IF NOT EXIST "!SSH_PAGEANT!" @GOTO ssh-pageant-done
+    )
+)
+
+@REM Time to make the donuts!
+@ECHO Starting ssh-pageant...
+@FOR /f "usebackq tokens=1 delims=;" %%o in (`"%SSH_PAGEANT%" -qra %SSH_AUTH_SOCK%`) DO @ECHO %%o
+
+:ssh-pageant-done
+:failure


### PR DESCRIPTION
This pull request is a sibling of [this one against git-for-windows/build-extra](https://github.com/git-for-windows/build-extra/pull/109), which adds [ssh-pageant integration](https://github.com/git-for-windows/git/issues/683) to Git for Windows. The ssh-pageant utility is drop-in replacement for ssh-agent, which allows OpenSSH to authenticate using keys stored in the PuTTY authentication agent (Pageant). Basically it makes it easier to use OpenSSH within Git, for those of us using PuTTY outside of the Git for Windows project.

This 2 commits in question simply add a `start-ssh-pageant.cmd` script, based upon `start-ssh-agent.cmd`, and updates the associated PKGBUILD to include it in the mingw-w64-git package build.

I had previously added a Wiki entry on manual [OpenSSH Integration with Pageant](https://github.com/git-for-windows/git/wiki/OpenSSH-Integration-with-Pageant). I'll make the necessary updates once ssh-pageant support has been integrated, and the final version/behavior of the script is known.