### PR TITLE
Allow for additional files for ssh-add

### DIFF
--- a/mingw-w64-git/start-ssh-agent.cmd
+++ b/mingw-w64-git/start-ssh-agent.cmd
@@ -90,7 +90,8 @@
     @IF EXIST "%HOME%\.ssh\%1" @(
         @SET KEYS='%HOME%\.ssh\%1' %KEYS%
     ) ELSE (
-        @echo Key '%1' not found.
+        @REM Assume full path...
+        @SET KEYS='%1' %KEYS%
     )
 )
 @GOTO :EOF

--- a/mingw-w64-git/start-ssh-agent.cmd
+++ b/mingw-w64-git/start-ssh-agent.cmd
@@ -70,9 +70,30 @@
             @ECHO. done
         )
         @"!SSH_ADD!"
+        @IF [!SSH_ADD_ADDITIONAL_KEYFILES!] NEQ [] @(
+            @SET KEYS=
+            @FOR %%I IN (!SSH_ADD_ADDITIONAL_KEYFILES!) DO @CALL :CHECKKEY %%I
+            IF NOT [!KEYS!] == [] @"!SSH_ADD!" !KEYS!
+        )
         @ECHO.
     )
 )
+
+@GOTO :ssh-agent-done
+
+
+@REM Functions
+@REM Check if ssh key has to be added
+:CHECKKEY
+@ssh-add -l | @FINDSTR /c:"%1" > NUL
+@IF ERRORLEVEL 1 @(
+    @IF EXIST "%HOME%\.ssh\%1" @(
+        @SET KEYS='%HOME%\.ssh\%1' %KEYS%
+    ) ELSE (
+        @echo Key '%1' not found.
+    )
+)
+@GOTO :EOF
 
 :ssh-agent-done
 :failure


### PR DESCRIPTION
According to the docs, ssh-add only adds certain keyfiles.

> ssh-add adds private key identities to the authentication agent, ssh-agent(1).
> When run without arguments, it adds the files ~/.ssh/id_rsa, ~/.ssh/id_dsa,
> ~/.ssh/id_ecdsa and ~/.ssh/identity.

Sometimes there is the need to add more keyfiles.

This is now possible by setting the SSH_ADD_ADDITIONAL_KEYFILES environment
variable to the comma separated list of additional keyfiles in ~/.ssh/

```bat
set "SSH_ADD_ADDITIONAL_KEYFILES=keyfile1_rsa,keyfile2_rsa2"
start-ssh-agent
```
Report: https://github.com/cmderdev/cmder/issues/1062