### PR TITLE
mingw-w64-git: adjust git-bash to official mintty

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -8,7 +8,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-man")
 tag=2.9.3.windows.2
 pkgver=2.9.3.2.f080fe7
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('any')
 url="https://git-for-windows.github.io/"
@@ -48,7 +48,7 @@ md5sums=('SKIP'
          '18763e83447859af27f30b316d7e9f64'
          'c9ce5141664cc7f221c06fcb8b4becb5'
          'fe57499d10c5fd319bce323aac321f71'
-         '24892485098f4b47d6d73e09f5a0ad39'
+         '7b8c17a00fc67e02ae37b2bdefaa9946'
          '0f3fb5d6fb2a591140f11de52745d4a2'
          'b2d7878989a5483705c0da5b92b39e80'
          'b2d7878989a5483705c0da5b92b39e80'
@@ -187,7 +187,6 @@ package_git () {
 
   # Git Bash, Git CMD
   install -d -m755 $pkgdir$SHAREDIR
-  install -m755 ../git-for-windows.ico $pkgdir$SHAREDIR
   install -m755 git-bash.exe git-cmd.exe $pkgdir
 
   # Compatibility Bash

--- a/mingw-w64-git/git-bash.rc
+++ b/mingw-w64-git/git-bash.rc
@@ -1,10 +1,6 @@
 STRINGTABLE
 BEGIN
-#ifdef _WIN64
-	0 "APP_ID=GitForWindows.Bash ALLOC_CONSOLE=1 usr\\bin\\mintty.exe -o AppID=GitForWindows.Bash -o RelaunchCommand=""@@EXEPATH@@\\git-bash.exe"" -o RelaunchDisplayName=""Git Bash"" -i /mingw64/share/git/git-for-windows.ico /usr/bin/bash --login -i"
-#else
-	0 "APP_ID=GitForWindows.Bash ALLOC_CONSOLE=1 usr\\bin\\mintty.exe -o AppID=GitForWindows.Bash -o RelaunchCommand=""@@EXEPATH@@\\git-bash.exe"" -o RelaunchDisplayName=""Git Bash"" -i /mingw32/share/git/git-for-windows.ico /usr/bin/bash --login -i"
-#endif
+	0 "APP_ID=GitForWindows.Bash ALLOC_CONSOLE=1 usr\\bin\\mintty.exe -o AppID=GitForWindows.Bash -o AppLaunchCmd=""@@EXEPATH@@\\git-bash.exe"" -o AppName=""Git Bash"" -i ""@@EXEPATH@@\\git-bash.exe"" --store-taskbar-properties -- /usr/bin/bash --login -i"
 	1 "SHOW_CONSOLE=1 APPEND_QUOTE=1 @@COMSPEC@@ /S /C """"@@EXEPATH@@\\usr\\bin\\bash.exe"" --login -i"
 END
 


### PR DESCRIPTION
Currently git-bash relies on mintty options that were proposed in a pull
request. A mintty package was also build with these changes. However, the
proposed options were changed slightly when merged into the official
mintty.

Offical mintty uses AppLaunchCmd instead of RelaunchCommand, AppName
instead of RelaunchDisplayName and requires an additional option
--store-taskbar-properties for the options to take effect.

In addition to these changes, specifying the path for the icon as
/mingw64/share/git/git-for-windows.ico no longer works. Using
"@@EXEPATH@@\\mingw64\\share\\git\\git-for-windows.ico" works, however,
instead of relying on a separate file we can just as well get the icon
from our git-bash executable.