### PR TITLE
mingw-w64-curl: add winssl-bin package configuration

### DIFF
--- a/mingw-w64-curl/.gitignore
+++ b/mingw-w64-curl/.gitignore
@@ -1,0 +1,1 @@
+/PKGBUILD-winssl-bin

--- a/mingw-w64-curl/PKGBUILD-winssl-bin.patch
+++ b/mingw-w64-curl/PKGBUILD-winssl-bin.patch
@@ -1,0 +1,49 @@
+--- PKGBUILD	2017-02-28 10:05:21.330804200 +0300
++++ PKGBUILD-winssl-bin	2017-02-28 10:13:15.667964800 +0300
+@@ -1,6 +1,6 @@
+ # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+-_variant=-openssl
+-#_variant=-winssl
++#_variant=-openssl
++_variant=-winssl
+ #_variant=-gnutls
+ 
+ if [ "${_variant}" = "-openssl" ]; then
+@@ -11,7 +11,7 @@
+ 
+ _realname=curl
+ pkgbase=mingw-w64-${_realname}
+-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
++pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}-bin"
+ pkgver=7.53.1
+ pkgrel=1
+ pkgdesc="An URL retrival utility and library. (mingw-w64)"
+@@ -33,11 +33,8 @@
+          $([[ "$_variant" == "-gnutls" ]] && echo \
+             "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
+             "${MINGW_PACKAGE_PREFIX}-gnutls")
++         "${MINGW_PACKAGE_PREFIX}-${_realname}"
+          )
+-if [ -n "${_namesuff}" ]; then
+-  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+-  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+-fi
+ options=('staticlibs')
+ source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
+         "0001-Make-cURL-relocatable.patch"
+@@ -106,8 +103,11 @@
+ 
+ package() {
+   cd "${srcdir}/build-${CARCH}"
+-  make DESTDIR="${pkgdir}" install
+-  
+-  local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
+-  sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/bin/curl-config
++  make DESTDIR="${pkgdir}-tmp" install
++
++  install -d -m755 "${pkgdir}/${MINGW_PREFIX}/bin/curl-winssl"
++  install -m755 "${pkgdir}-tmp/${MINGW_PREFIX}/bin/curl.exe" "${pkgdir}/${MINGW_PREFIX}/bin/curl-winssl"
++  install -m755 "${pkgdir}-tmp/${MINGW_PREFIX}/bin/libcurl-4.dll" "${pkgdir}/${MINGW_PREFIX}/bin/curl-winssl"
++
++  rm -rf "${pkgdir}-tmp"
+ }

--- a/mingw-w64-curl/make-PKGBUILD-winssl-bin.sh
+++ b/mingw-w64-curl/make-PKGBUILD-winssl-bin.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# The script generates PKGBUILD-winssl-bin file from base PKGBUILD file.
+#
+# mingw-w64-curl-winssl-bin package built from PKGBUILD-winssl-bin
+# provides only binary files (.exe and .dll) in /mingw64/bin/curl-winssl.
+# The package is used in Git for Windows to distribute cURL built with WinSSL
+# along with cRUL built with OpenSSL which is used by default.
+#
+# The script uses a patch file generated with the following command:
+# $ diff -u PKGBUILD PKGBUILD-winssl-bin >PKGBUILD-winssl-bin.patch
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+patch -i PKGBUILD-winssl-bin.patch -o PKGBUILD-winssl-bin ||
+die "Could not patch PKGBUILD"


### PR DESCRIPTION
mingw-w64-curl-winssl-bin contains only binary files installed to /mingw64/bin/curl-winssl. The package depends on mingw-w64-curl which provides all the rest.

PKGBUILD-winssl-bin is generated from PKGBUILD with a patch file.

See discussion in the issue for more details: https://github.com/git-for-windows/git/issues/301

I don't run makepkg-mingw at the end of the script because `please.sh` uses more complex code:
```
"$sdk/git-cmd.exe" --command=usr\\bin\\sh.exe -l -c \
	'MAKEFLAGS=-j5 MINGW_INSTALLS=mingw32\ mingw64 \
		'"$extra"'makepkg-mingw -s --noconfirm &&
	 MINGW_INSTALLS=mingw64 makepkg-mingw --allsource' ||
die "%s: could not build\n" "$sdk/$pkgpath"
```
I think the code should be modified to use PKGBUILD scripts with various file names.