### PR TITLE
mingw-w64-git: add support to git-wrapper for wrapping git-lfs

### DIFF
--- a/mingw-w64-git/git-wrapper.c
+++ b/mingw-w64-git/git-wrapper.c
@@ -515,6 +515,14 @@ int main(void)
 			&show_console, &append_quote_to_cmdline)) {
 		/* do nothing */
 	}
+	else if (!wcsicmp(basename, L"git-lfs.exe")) {
+		initialize_top_level_path(top_level_path, exepath, NULL, 1);
+
+		/* set the default exe module */
+		wcscpy(exe, top_level_path);
+		PathAppend(exe, msystem_bin);
+		PathAppend(exe, L"git-lfs.exe");
+	}
 	else if (!wcsicmp(basename, L"git-gui.exe") ||
 			!wcsicmp(basename, L"gitk.exe")) {
 		static WCHAR buffer[BUFSIZE];


### PR DESCRIPTION
Support for git-lfs wrapping in `/cmd`, see git-for-windows/git#1503