### PR TITLE
Add mingw-w64-git.mak

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -48,7 +48,8 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 	'git-cmd.rc'
 	'git-wrapper.rc'
 	'gitk.rc'
-	'compat-bash.rc')
+	'compat-bash.rc'
+	'mingw-w64-git.mak')
 
 sha256sums=('SKIP'
             '62f455747f33953a723ff7b070d43f0ed03c1d8d0749d7bb06288e14d356b637'
@@ -59,7 +60,8 @@ sha256sums=('SKIP'
             '83b766b3dd0c9fe50062041a2ab7d8a2b5f062d7278048085e78d7fbe9e5045c'
             '0726d386e98d703d5254458056e02824fb3de5602e55a31ec0cddf67c302c3a4'
             '0726d386e98d703d5254458056e02824fb3de5602e55a31ec0cddf67c302c3a4'
-            'cbed8b133eb9eec9972f146be5c3ff49db29b2fff8ab9c87a6d0c646c08a5128')
+            'cbed8b133eb9eec9972f146be5c3ff49db29b2fff8ab9c87a6d0c646c08a5128'
+            'e91651695a7f270652d6d5fc20d88fc4d51c7e7b528556770a59ab425bd4650c')
 
 pkgver() {
   cd "$srcdir/git"
@@ -128,67 +130,10 @@ build() {
 
   # git-credential-wincred.exe
   make -C contrib/credential/wincred clean all &&
-
-  cat >mingw-w64-git.mak <<\EOF &&
-include Makefile
-
-git-wrapper$(X): git-wrapper.o git.res
-	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) \
-		-fno-stack-protector -Wall -o $@ $^ -lshell32 -lshlwapi
-
-git-wrapper.o: %.o: ../%.c GIT-PREFIX
-	$(QUIET_CC)$(CC) $(ALL_CFLAGS) $(COMPAT_CFLAGS) \
-		-fno-stack-protector -o $*.o -c -Wall -Wwrite-strings $<
-
-git-bash.res git-cmd.res git-wrapper.res gitk.res compat-bash.res: \
-		%.res: ../%.rc
-	$(QUIET_RC)$(RC) -i $< -o $@
-
-git-bash.exe cmd/gitk.exe cmd/git-gui.exe: ALL_LDFLAGS += -mwindows
-
-git-bash.exe git-cmd.exe compat-bash.exe: %.exe: %.res
-
-cmd/gitk.exe cmd/git-gui.exe: gitk.res
-
-git-bash.exe git-cmd.exe compat-bash.exe \
-cmd/git.exe cmd/gitk.exe cmd/git-gui.exe: \
-		%.exe: git-wrapper.o git.res
-	@mkdir -p cmd
-	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) -o $@ $^ -lshlwapi
-
-print-builtins:
-	@echo $(BUILT_INS)
-
-strip-all: strip
-	$(STRIP) $(STRIP_OPTS) \
-		contrib/credential/wincred/git-credential-wincred.exe \
-		cmd/git{,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
-
-install-pdbs:
-	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(bindir_SQ)'
-	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
-	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)/cmd'
-	$(INSTALL) -m 644 git.pdb '$(DESTDIR_SQ)$(bindir_SQ)'
-	$(INSTALL) -m 644 $(patsubst %.exe,%.pdb,$(PROGRAMS)) \
-		contrib/credential/wincred/git-credential-wincred.pdb \
-		'$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
-	$(INSTALL) -m 644 cmd/git{,-gui,k}.pdb '$(DESTDIR_SQ)/cmd'
-	$(INSTALL) -m 644 git-{bash,cmd,wrapper}.pdb '$(DESTDIR_SQ)'
-
-sign-executables:
-ifeq (,$(SIGNTOOL))
-	@echo Skipping code-signing
-else
-	@eval $(SIGNTOOL) $(filter %.exe,$(ALL_PROGRAMS)) \
-		contrib/credential/wincred/git-credential-wincred.exe git.exe \
-		cmd/git{,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
-endif
-EOF
-
   CC=gcc make -C contrib/credential/wincred &&
 
   rm -f *.res &&
-  make -f mingw-w64-git.mak git-wrapper.exe \
+  make -f ../mingw-w64-git.mak git-wrapper.exe \
 	git-bash.exe git-cmd.exe compat-bash.exe \
 	cmd/git.exe cmd/gitk.exe cmd/git-gui.exe &&
 
@@ -196,9 +141,9 @@ EOF
   printf '#!/bin/sh\n\nfor arg; do\n\t%s || exit\n\t%s || exit\ndone\n' \
 	'test 1 -eq $(stat -c %h "$arg") || { cp "$arg" .1 && mv .1 "$arg"; }' \
 	'test "${arg%.exe}.pdb" -nt "$arg" || cv2pdb "$arg"' >cv2pdb-strip &&
-  make -f mingw-w64-git.mak STRIP=$PWD/cv2pdb-strip STRIP_OPTS= strip-all &&
-  make -f mingw-w64-git.mak sign-executables &&
-  make -f mingw-w64-git.mak print-builtins | tr ' ' '\n' > builtins.txt
+  make -f ../mingw-w64-git.mak STRIP=$PWD/cv2pdb-strip STRIP_OPTS= strip-all &&
+  make -f ../mingw-w64-git.mak sign-executables &&
+  make -f ../mingw-w64-git.mak print-builtins | tr ' ' '\n' > builtins.txt
 }
 
 package_git () {
@@ -263,7 +208,7 @@ package_git-test-artifacts () {
 package_git-pdb () {
   cd "$srcdir"/git
 
-  make -f mingw-w64-git.mak DESTDIR="$pkgdir" install-pdbs
+  make -f ../mingw-w64-git.mak DESTDIR="$pkgdir" install-pdbs
 }
 
 package_mingw-w64-i686-git () {

--- a/mingw-w64-git/mingw-w64-git.mak
+++ b/mingw-w64-git/mingw-w64-git.mak
@@ -1,0 +1,53 @@
+include Makefile
+
+git-wrapper$(X): git-wrapper.o git.res
+	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) \
+		-fno-stack-protector -Wall -o $@ $^ -lshell32 -lshlwapi
+
+git-wrapper.o: %.o: ../%.c GIT-PREFIX
+	$(QUIET_CC)$(CC) $(ALL_CFLAGS) $(COMPAT_CFLAGS) \
+		-fno-stack-protector -o $*.o -c -Wall -Wwrite-strings $<
+
+git-bash.res git-cmd.res git-wrapper.res gitk.res compat-bash.res: \
+		%.res: ../%.rc
+	$(QUIET_RC)$(RC) -i $< -o $@
+
+git-bash.exe cmd/gitk.exe cmd/git-gui.exe: ALL_LDFLAGS += -mwindows
+
+git-bash.exe git-cmd.exe compat-bash.exe: %.exe: %.res
+
+cmd/gitk.exe cmd/git-gui.exe: gitk.res
+
+git-bash.exe git-cmd.exe compat-bash.exe \
+cmd/git.exe cmd/gitk.exe cmd/git-gui.exe: \
+		%.exe: git-wrapper.o git.res
+	@mkdir -p cmd
+	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) -o $@ $^ -lshlwapi
+
+print-builtins:
+	@echo $(BUILT_INS)
+
+strip-all: strip
+	$(STRIP) $(STRIP_OPTS) \
+		contrib/credential/wincred/git-credential-wincred.exe \
+		cmd/git{,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
+
+install-pdbs:
+	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(bindir_SQ)'
+	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
+	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)/cmd'
+	$(INSTALL) -m 644 git.pdb '$(DESTDIR_SQ)$(bindir_SQ)'
+	$(INSTALL) -m 644 $(patsubst %.exe,%.pdb,$(PROGRAMS)) \
+		contrib/credential/wincred/git-credential-wincred.pdb \
+		'$(DESTDIR_SQ)$(gitexec_instdir_SQ)'
+	$(INSTALL) -m 644 cmd/git{,-gui,k}.pdb '$(DESTDIR_SQ)/cmd'
+	$(INSTALL) -m 644 git-{bash,cmd,wrapper}.pdb '$(DESTDIR_SQ)'
+
+sign-executables:
+ifeq (,$(SIGNTOOL))
+	@echo Skipping code-signing
+else
+	@eval $(SIGNTOOL) $(filter %.exe,$(ALL_PROGRAMS)) \
+		contrib/credential/wincred/git-credential-wincred.exe git.exe \
+		cmd/git{,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
+endif


### PR DESCRIPTION
Add mak file to build wrappers faster. It's a copy from MAKEPKG file: maybe it's easier to have only one copy of this text stored in the separate file?

I also created Wiki page, I guess it could be useful for other developers. I can't add it to Git For Windows project because it does not have Wiki at all, you can read it from my fork:
https://github.com/telezhnaya/MINGW-packages/wiki/FAQ:-Git-package