### PR TITLE
git: fix the MAX_PATH handling of the Git wrapper

### DIFF
--- a/mingw-w64-git/git-wrapper.c
+++ b/mingw-w64-git/git-wrapper.c
@@ -14,6 +14,10 @@
 #include <stdio.h>
 #include <wchar.h>
 
+/* Let the system deal with it if the path is too long */
+#undef MAX_PATH
+#define MAX_PATH 4096
+
 static WCHAR msystem_bin[64];
 
 static void print_error(LPCWSTR prefix, DWORD error_number)


### PR DESCRIPTION
There were a couple of mistakes there, including restricting the maximal length of Git's top-level directory too much, causing https://github.com/git-for-windows/git/issues/1764