### PR TITLE
Update 0023-win32-work-around-stat-fstat-defines.patch

### DIFF
--- a/mingw-w64-nodejs/0023-win32-work-around-stat-fstat-defines.patch
+++ b/mingw-w64-nodejs/0023-win32-work-around-stat-fstat-defines.patch
@@ -11,14 +11,14 @@ respective prefix and the terms `stat` or `fstat`.
 
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
 ---
- deps/uv/include/uv.h | 4 ++++
- 1 file changed, 4 insertions(+)
+ deps/uv/include/uv.h | 6 ++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/deps/uv/include/uv.h b/deps/uv/include/uv.h
 index 9794d996..96719b2f 100644
 --- a/deps/uv/include/uv.h
 +++ b/deps/uv/include/uv.h
-@@ -1217,6 +1217,10 @@ UV_EXTERN int uv_fs_scandir(uv_loop_t* loop,
+@@ -1217,6 +1217,12 @@ UV_EXTERN int uv_fs_scandir(uv_loop_t* loop,
                              uv_fs_cb cb);
  UV_EXTERN int uv_fs_scandir_next(uv_fs_t* req,
                                   uv_dirent_t* ent);


### PR DESCRIPTION
The previous commit added lines to the patch, but did not update the corresponding line numbers, which resulted in a malformed patch. This change updates the line numbers to account for the new lines.