### PR TITLE
Update libidn2

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
 pkgver=7.63.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
 url="https://curl.haxx.se"


### PR DESCRIPTION
This closes https://github.com/git-for-windows/git/issues/2034, I think.

I don't know the details of the build system, so I'm not sure if the `libidn2` update to `2.1.0` would get picked up by the rebuild of `curl` if they were in the same PR and possibly (?) built at the same time (?).

The changes besides `curl` are for dependants of `libidn2` that have been rebuilt upstream.

All commits have been cherry-picked from upstream since the histories have diverged too much. There were several conflicts due to a major change of `curl` in 0c9d339b1e19fdcce4753bb27573b8440076e9c9. Perhaps that would be useful upstream?