### PR TITLE
git: optionally build without PDBs

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -6,8 +6,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-html"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-doc-man"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-test-artifacts"
-	 "${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
+	 "${MINGW_PACKAGE_PREFIX}-${_realname}-test-artifacts")
 tag=2.22.0.windows.1
 pkgver=2.22.0.1.d003d728ff
 pkgrel=1
@@ -16,11 +15,10 @@ arch=('any')
 url="https://git-for-windows.github.io/"
 license=('GPL2')
 
-options=('!strip')
+options=()
 makedepends=('python2' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
 	'ca-certificates' 'asciidoc' 'xmlto'
-	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions"
-	"${MINGW_PACKAGE_PREFIX}-cv2pdb")
+	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
 
 case "$(printf "%s\n%s\n" "$pkgver" "2.18.0" | sort -V)" in
 2.18.0*) pcre="${MINGW_PACKAGE_PREFIX}-pcre2";;
@@ -69,6 +67,15 @@ sha256sums=('SKIP'
             'cbed8b133eb9eec9972f146be5c3ff49db29b2fff8ab9c87a6d0c646c08a5128'
             'c9d82a0bbe2c2dbd22de8478899e7f159a96c3c97a99a1470c3cbc29c4ee09ac'
             '79bb4745063bc3e67831da1f694be0e98998b653a3e334e24db57500b1fee108')
+
+if test -z "$WITHOUT_PDBS"
+then
+	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
+	makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
+	options+=('!strip')
+else
+	options+=('strip')
+fi
 
 pkgver() {
   cd "$srcdir/git"
@@ -149,7 +156,9 @@ build() {
     }
   done &&
 
-  make -f ../mingw-w64-git.mak STRIP=$PWD/../cv2pdb-strip STRIP_OPTS= strip-all &&
+  case "${pkgname[@]}" in *pdb*)
+    make -f ../mingw-w64-git.mak STRIP=$PWD/../cv2pdb-strip STRIP_OPTS= strip-all;;
+  esac &&
   make -f ../mingw-w64-git.mak sign-executables &&
   make -f ../mingw-w64-git.mak print-builtins | tr ' ' '\n' > builtins.txt
 }


### PR DESCRIPTION
Let's offer a way to build `mingw-w64-git` without having Visual Studio installed.