### PR TITLE
git: avoid problems with the sha1collisiondetection submodule

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -130,7 +130,7 @@ build() {
   then
     git config core.autocrlf false
     rm .git/index
-    git stash
+    git reset --hard
   fi
 
   # Git wants to decide itself whether to use ANSI stdio emulation or not


### PR DESCRIPTION
@telezhnaya reported a long time ago that an initial build of the `mingw-w64-git` package fails, with an obscure error message that the empty `sha1collisiondetection` directory cannot be added.

Turns out that this happens while we want to make sure that Git is checked out with `core.autocrlf=false`, and the symptom is caused by a bug in `git stash`.

We do not _have_ to use `git stash`, so let's use `git reset --hard` instead.