### PR TITLE
mingw-w64-curl: Update PKGBUILD in order to build with libssh2.

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -71,6 +71,7 @@ build() {
     --enable-shared \
     --enable-sspi \
     --with-libmetalink=${MINGW_PREFIX} \
+    --with-libssh2 \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.
 # curl has to specified with the file extension.


### PR DESCRIPTION
cURL, starting with version 7.58, changed build settings around SSH support so that MinGW builds of cURL made since have scp and scftp protocols support disabled.

This commit re-enabled SSH support for MinGW builds.

PR for issue https://github.com/git-for-windows/git/issues/2491.