### PR TITLE
git (git-bash): parse a file to opt-in to pseudo console support

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -55,7 +55,8 @@ source=("${_realname}"::"git+https://github.com/git-for-windows/git.git#tag=v$ta
 	'gitk.rc'
 	'compat-bash.rc'
 	'mingw-w64-git.mak'
-	'cv2pdb-strip')
+	'cv2pdb-strip'
+	'edit-git-bash.c')
 
 sha256sums=('SKIP'
             '62f455747f33953a723ff7b070d43f0ed03c1d8d0749d7bb06288e14d356b637'
@@ -146,7 +147,8 @@ build() {
   rm -f *.res &&
   make -f ../mingw-w64-git.mak git-wrapper.exe \
 	git-bash.exe git-cmd.exe compat-bash.exe \
-	cmd/git.exe cmd/gitk.exe cmd/git-gui.exe &&
+	cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
+	edit-git-bash.exe &&
   rm -f *.res &&
 
   # Also build git-credential-wincred.exe before the rest, so that those
@@ -202,6 +204,7 @@ package_git () {
   install -d -m755 $pkgdir$SHAREDIR
   install -m755 ../git-for-windows.ico $pkgdir$SHAREDIR
   install -m755 git-bash.exe git-cmd.exe $pkgdir
+  install -m755 edit-git-bash.exe $pkgdir$SHAREDIR
 
   # Compatibility Bash, git-wrapper.exe
   install -m755 compat-bash.exe git-wrapper.exe $pkgdir$SHAREDIR

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -19,6 +19,7 @@ options=()
 makedepends=('python2' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
 	'ca-certificates' 'asciidoc' 'xmlto'
 	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
+install=git.install
 
 case "$(printf "%s\n%s\n" "$pkgver" "2.18.0" | sort -V)" in
 2.18.0*) pcre="${MINGW_PACKAGE_PREFIX}-pcre2";;

--- a/mingw-w64-git/edit-git-bash.c
+++ b/mingw-w64-git/edit-git-bash.c
@@ -1,0 +1,94 @@
+#define STRICT
+#define WIN32_LEAN_AND_MEAN
+#define UNICODE
+#define _UNICODE
+#include <windows.h>
+#include <stdlib.h>
+
+#include <shellapi.h>
+#include <stdio.h>
+
+#ifdef DEBUG
+static void print_error(LPCWSTR prefix, DWORD error_number)
+{
+	LPWSTR buffer = NULL;
+	DWORD count = 0;
+
+	count = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+			| FORMAT_MESSAGE_FROM_SYSTEM
+			| FORMAT_MESSAGE_IGNORE_INSERTS,
+			NULL, error_number, LANG_NEUTRAL,
+			(LPTSTR)&buffer, 0, NULL);
+	if (count < 1)
+		count = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER
+				| FORMAT_MESSAGE_FROM_STRING
+				| FORMAT_MESSAGE_ARGUMENT_ARRAY,
+				L"Code 0x%1!08x!",
+				0, LANG_NEUTRAL, (LPTSTR)&buffer, 0,
+				(va_list*)&error_number);
+	MessageBox(NULL, buffer, prefix, MB_OK);
+	LocalFree((HLOCAL)buffer);
+}
+#endif
+
+static
+int edit_git_bash(LPWSTR git_bash_path, LPWSTR new_command_line)
+{
+	HANDLE handle;
+	int len, alloc, result = 0;
+	WCHAR *buffer;
+
+	len = wcslen(new_command_line);
+	alloc = 2 * (len + 16);
+	buffer = calloc(alloc, 1);
+
+	if (!buffer)
+		return 1;
+
+	buffer[0] = (WCHAR) len;
+	memcpy(buffer + 1, new_command_line, 2 * len);
+
+	if (!(handle = BeginUpdateResource(git_bash_path, FALSE)))
+		return 2;
+
+	if (!UpdateResource(handle, RT_STRING, MAKEINTRESOURCE(1),
+			MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+			buffer, alloc))
+		result = 3;
+
+	if (!EndUpdateResource(handle, FALSE))
+		return 4;
+
+	return result;
+}
+
+int main(int argc, char **argv)
+{
+	int wargc, result;
+	LPWSTR *wargv;
+
+#ifdef DEBUG
+	LPTSTR cmdLine = GetCommandLineW();
+	fwprintf(stderr, L"Command Line: %s\n", cmdLine);
+
+	wargv = CommandLineToArgvW(cmdLine, &wargc);
+
+	for (int i = 1; i < wargc; ++i)
+		fwprintf(stderr, L"Arg %d: %s\n", i, wargv[i]);
+#else
+	wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+#endif
+
+	if (wargc != 3) {
+		fwprintf(stderr, L"Usage: %s <path-to-exe> <new-commad-line>\n",
+			wargv[0]);
+		exit(1);
+	}
+
+	result = edit_git_bash(wargv[1], wargv[2]);
+
+	if (result)
+		fwprintf(stderr, L"Error editing %s: %d\n", wargv[1], result);
+
+	return result;
+}

--- a/mingw-w64-git/git.install
+++ b/mingw-w64-git/git.install
@@ -1,0 +1,37 @@
+mingw_prefix_path () {
+	case "$(uname -m)" in
+	x86_64) echo /mingw64;;
+	i686) echo /mingw32;;
+	esac
+}
+
+bin_path () {
+	echo "$(cygpath -am / | sed 's/^\([A-Z]\):/\/\1/')/bin"
+}
+
+copy_files () {
+	mkdir -p "$2" &&
+	cp "$1"/share/git/compat-bash.exe "$2"/bash.exe &&
+	cp "$1"/share/git/compat-bash.exe "$2"/sh.exe &&
+	cp /cmd/git.exe "$2"/
+}
+
+post_install () {
+	# Install git, bash and sh redirectors into the bin/ directory
+	# This needs to use the absolute path because /bin/ is overlayed by
+	# /usr/bin/.
+	copy_files $(mingw_prefix_path) "$(bin_path)"
+}
+
+post_upgrade () {
+	post_install
+}
+
+remove_files () {
+	rm "$1"/git.exe "$1"/bash.exe "$1"/sh.exe &&
+	{ test -n "$(ls -A "$1")" || rm -r "$1"; }
+}
+
+post_remove () {
+	remove_files "$(bin_path)"
+}

--- a/mingw-w64-git/mingw-w64-git.mak
+++ b/mingw-w64-git/mingw-w64-git.mak
@@ -24,6 +24,9 @@ cmd/git.exe cmd/gitk.exe cmd/git-gui.exe: \
 	@mkdir -p cmd
 	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) -o $@ $^ -lshlwapi
 
+edit-git-bash.exe: ../edit-git-bash.c
+	$(QUIET_CC)$(CC) $(ALL_CFLAGS) -o $@ $^
+
 print-builtins:
 	@echo $(BUILT_INS)
 


### PR DESCRIPTION
The main thrust of this PR is to allow telling Git Bash that the user wants to opt-in to the pseudo console support. With this PR, we allow doing that by writing `MSYS=enable_pcon` into `/etc/git-bash.config`.

This PR looks a bit more complicated than absolutely necessary because I slipped in two more things (because I wanted them for ages): by default, we now install the git/bash/sh redirectors into `/bin/` in the Git for Windows SDK (which will come in _real_ handy especially in automation, no more `git-cmd.exe --command=usr\bin\bash.exe` awkwardness), and we also include the `edit-git-bash` helper (because it makes the most sense, as `mingw-w64-git` owns `git-bash.exe`).