### PR TITLE
Handle UNC paths correctly when making cURL relocatable

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -26,10 +26,10 @@ Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
  configure.ac         |   1 +
  lib/Makefile.inc     |   2 +
  lib/curl_config.h.in |   3 +
- lib/pathtools.c      | 556 +++++++++++++++++++++++++++++++++++++++++++
+ lib/pathtools.c      | 562 +++++++++++++++++++++++++++++++++++++++++++
  lib/pathtools.h      |  57 +++++
  lib/url.c            |  26 +-
- 6 files changed, 644 insertions(+), 1 deletion(-)
+ 6 files changed, 650 insertions(+), 1 deletion(-)
  create mode 100644 lib/pathtools.c
  create mode 100644 lib/pathtools.h
 
@@ -81,10 +81,10 @@ index 89a1d195a..8c8305754 100644
  
 diff --git a/lib/pathtools.c b/lib/pathtools.c
 new file mode 100644
-index 000000000..c09458e95
+index 000000000..53d0db00b
 --- /dev/null
 +++ b/lib/pathtools.c
-@@ -0,0 +1,556 @@
+@@ -0,0 +1,562 @@
 +/*
 +      .Some useful path tools.
 +        .ASCII only for now.
@@ -156,7 +156,7 @@ index 000000000..c09458e95
 +    *path_p = '/';
 +  }
 +  /* Replace any '//' with '/' */
-+  path_p = path;
++  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
 +  while ((path_p = strstr (path_p, "//")) != NULL)
 +  {
 +    memmove (path_p, path_p + 1, path_size--);
@@ -277,6 +277,12 @@ index 000000000..c09458e95
 +  char * result = path;
 +  char * result_p;
 +  char const ** toks;
++  if (path[0] == '/' && path[1] == '/') {
++    /* preserve UNC path */
++    path++;
++    in_size--;
++    result++;
++  }
 +  sanitise_path(result);
 +  result_p = result;
 +


### PR DESCRIPTION
This fixes https://github.com/git-for-windows/git/issues/3266