### PR TITLE
Add a GitHub workflow to build and deploy a single MINGW package

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,172 @@
+name: build-and-deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'The package to build'
+        required: true
+      architecture:
+        description: 'The CPU architecture package to build'
+        default: x86_64
+        required: false
+      build_only:
+        description: 'Skip deployment (if non-empty)'
+        required: false
+      debug_with_ssh_key:
+        description: 'Public SSH key to use to debug failures'
+        required: false
+
+env:
+  PACKAGE_TO_BUILD: "${{github.event.inputs.package}}"
+  GPG_OPTIONS: "--batch --yes --no-tty --list-options no-show-photos --verify-options no-show-photos --pinentry-mode loopback"
+  HOME: "${{github.workspace}}\\home"
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    environment: build-pacman-packages
+    steps:
+      - name: Configure build
+        shell: bash
+        run:
+          USER_NAME="${{github.actor}}" &&
+          USER_EMAIL="${{github.actor}}@users.noreply.github.com" &&
+          mkdir "$HOME" &&
+          git config --global user.name "$USER_NAME" &&
+          git config --global user.email "$USER_EMAIL" &&
+          echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV &&
+
+          case "${{github.event.inputs.architecture}}" in
+          x86_64) MINGW_ARCH=mingw64;;
+          i686) MINGW_ARCH=mingw32;;
+          esac &&
+          echo "MINGW_ARCH=$MINGW_ARCH" >>$GITHUB_ENV &&
+          echo "MAKEFLAGS=-j8" >>$GITHUB_ENV &&
+          echo "PKGEXT=.pkg.tar.xz" >>$GITHUB_ENV
+      - name: Download Git for Windows SDK
+        uses: git-for-windows/setup-git-for-windows-sdk@v1
+        with:
+          flavor: full
+          architecture: ${{github.event.inputs.architecture}}
+      - name: Clone MINGW-packages
+        shell: bash
+        env:
+          REF: "${{github.ref}}"
+        run: |
+          mkdir -p /usr/src &&
+          git clone --depth 1 --single-branch -b "${REF#refs/heads/}" https://github.com/${{github.repository}} /usr/src/MINGW-packages
+      - name: Clone build-extra
+        shell: bash
+        run: git clone --depth 1 --single-branch -b main https://github.com/git-for-windows/build-extra /usr/src/build-extra
+      - name: pacman -Syyu
+        shell: bash
+        run: pacman -Syyu --noconfirm
+      - name: Get GPG key(s)
+        shell: bash
+        run: |
+          cd "/usr/src/MINGW-packages/${{github.event.inputs.package}}" &&
+          . PKGBUILD &&
+          for key in "${validpgpkeys[@]}" 57759F748D223F034D8BE870BB3AA74136C569BB
+          do
+            gpg $GPG_OPTIONS --recv-keys --batch --yes --keyserver hkp://keyserver.ubuntu.com "$key" &&
+            echo "$key:6:" | gpg $GPG_OPTIONS --import-ownertrust ||
+            exit 1
+          done
+      - name: Prepare home directory for GPG signing
+        if: env.GPGKEY != ''
+        shell: bash
+        run: |
+          echo '${{secrets.PRIVGPGKEY}}' | tr % '\n' | gpg $GPG_OPTIONS --import &&
+          mkdir -p home &&
+          git config --global gpg.program "/usr/src/build-extra/gnupg-with-gpgkey.sh" &&
+          info="$(gpg --list-keys --with-colons "${GPGKEY%% *}" | cut -d : -f 1,10 | sed -n '/^uid/{s|uid:||p;q}')" &&
+          git config --global user.name "${info% <*}" &&
+          git config --global user.email "<${info#*<}"
+          echo "PACKAGER=$info" >>$GITHUB_ENV
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
+      - name: Prepare home directory for code-signing
+        if: env.CODESIGN_P12 != '' && env.CODESIGN_PASS != ''
+        env:
+          CODESIGN_P12: ${{secrets.CODESIGN_P12}}
+          CODESIGN_PASS: ${{secrets.CODESIGN_PASS}}
+        shell: bash
+        run: |
+          mkdir -p home/.sig &&
+          echo "$CODESIGN_P12" | tr % '\n' | base64 -d >home/.sig/codesign.p12 &&
+          echo "$CODESIGN_PASS" >home/.sig/codesign.pass
+          git config --global alias.signtool '!sh "/usr/src/build-extra/signtool.sh"'
+      - name: Build ${{github.event.inputs.package}}
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
+        shell: bash
+        run: |
+          # Let `cv2pdb` find the DLLs
+          PATH="$PATH:/c/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin" &&
+
+          dir="$(cygpath -au artifacts)" &&
+          mkdir -p "$dir" &&
+          cd "/usr/src/MINGW-packages/${{github.event.inputs.package}}" &&
+          makepkg-mingw -s --noconfirm &&
+          ls -la &&
+          cp *.pkg.tar* "$dir/"
+      - name: Build ${{github.event.inputs.package}} source package
+        if: ${{github.event.inputs.architecture}} == 'x86_64'
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
+        shell: bash
+        run: |
+          dir="$(cygpath -au artifacts)" &&
+          mkdir -p "$dir" &&
+          cd "/usr/src/MINGW-packages/${{github.event.inputs.package}}" &&
+          makepkg-mingw --allsource &&
+          ls -la &&
+          cp *.pkg.tar* "$dir/"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+      - name: Prepare home directory for deploying to the Pacman repository
+        if: github.event.inputs.build_only != 'true' && env.AZURE_BLOBS_TOKEN != ''
+        env:
+          AZURE_BLOBS_TOKEN: ${{secrets.AZURE_BLOBS_TOKEN}}
+        shell: bash
+        run: echo "$AZURE_BLOBS_TOKEN" >"$HOME"/.azure-blobs-token
+      - name: Deploy Pacman packages
+        shell: bash
+        env:
+          GPGKEY: ${{secrets.GPGKEY}}
+          FALLBACK_ARCHITECTURE: ${{github.event.inputs.architecture}}
+          PACMANDRYRUN: ${{github.event.inputs.build_only}}
+        run: /usr/src/build-extra/pacman-helper.sh quick_add artifacts/*
+      - name: Debug using tmate
+        if: failure() && github.event.inputs.debug_with_ssh_key != ''
+        shell: bash
+        run: |
+          # Install tmate
+          pacman -Sy --noconfirm tmate openssh &&
+
+          # Restrict SSH access to the "actor", i.e. the GitHub user who triggered this workflow
+          mkdir -p ~/.ssh &&
+          echo '${{github.event.inputs.debug_with_ssh_key}}' >~/.ssh/authorized_keys &&
+
+          # Generate an SSH key (needed for tmate)
+          echo -e 'y\n' | ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa &&
+
+          # Start tmate session
+          export CHERE_INVOKING=1 &&
+          tmate -S /tmp/tmate.sock -a ~/.ssh/authorized_keys new-session -d &&
+          tmate -S /tmp/tmate.sock wait tmate-ready &&
+
+          # Print SSH invocation every 5 seconds, until tmate session has terminated
+          while test -e /tmp/tmate.sock
+          do
+            tmate -S /tmp/tmate.sock display -p '#{tmate_ssh}'
+            sleep 5
+          done
+      - name: Clean up temporary files
+        if: always()
+        shell: bash
+        run: rm -rf home


### PR DESCRIPTION
This is the equivalent to https://github.com/git-for-windows/MSYS2-packages/blob/main/.github/workflows/build-and-deploy.yml, and was prepared in case we need it to build `mingw-w64-gettext` to be able to build Git for Windows v2.35.0-rc0.

We no longer need this _urgently_, but I open this PR anyway because it will provide a good starting point when we start transitioning Git for Windows' packaging process away from Azure Pipelines toward GitHub workflows (and probably also away from doing everything in `/usr/src/build-extra/please.sh upgrade <package>` toward a more PR-centric flow).