### PR TITLE
git: do not depend on Python v2.x nor on AsciiDoc

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -16,9 +16,8 @@ url="https://git-for-windows.github.io/"
 license=('GPL2')
 
 options=()
-makedepends=('python2' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
-	'ca-certificates' 'asciidoc' 'xmlto'
-	"${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
+makedepends=('python' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
+	'ca-certificates' 'xmlto' "${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
 install=git.install
 
 case "$(printf "%s\n%s\n" "$pkgver" "2.18.0" | sort -V)" in


### PR DESCRIPTION
As part of [some spring cleaning](https://github.com/git-for-windows/git-sdk-64/compare/b11327be14...0185b0666c) of the Git for Windows SDK, I noticed that we still had Python v2.x and AsciiDoc because they are listed as dependencies of `mingw-w64-git`. But we don't actually need them...