### PR TITLE
mingw-w64-xpdf: fix source URL

### DIFF
--- a/mingw-w64-xpdf/PKGBUILD
+++ b/mingw-w64-xpdf/PKGBUILD
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-zlib")
 options=('strip')
-source=(https://xpdfreader-dl.s3.amazonaws.com/xpdf-${pkgver}.tar.gz{,.sig}
+source=(https://dl.xpdfreader.com/old/xpdf-${pkgver}.tar.gz{,.sig}
         001-cmake.patch
         002-xpdf-4.00-64bit.patch
         003-xpdf-4.00-libpaperfix.patch


### PR DESCRIPTION
Apparently, xpdf has changed their download URLs. The old S3-based URL no longer works. Looking at their website (xpdfreader.com), it seems that their download domain is now dl.xpdfreader.com. Since the SHA256 of the file hasn't changed, we can consider this to be a safe change.

Signed-off-by: Dennis Ameling <dennis@dennisameling.com>