### PR TITLE
mingw-w64-curl: Add ARM64 support

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w
 arch=('any')
 url="https://curl.haxx.se"
 license=("MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-c-ares"
          "${MINGW_PACKAGE_PREFIX}-libidn2"
@@ -32,11 +32,18 @@ validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
               '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
               '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
 
-if test -z "$WITHOUT_PDBS"
+if [[ "$MSYSTEM" == CLANG* && -z "$WITHOUT_PDBS" ]]
+then
+	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
+	options+=('!strip')
+	STRIP=llvm-strip
+	STRIP_OPTS=--strip-debug
+elif test -z "$WITHOUT_PDBS"
 then
 	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
 	makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
 	options+=('!strip')
+	STRIP=cv2pdb
 else
 	options+=('strip')
 fi
@@ -53,6 +60,8 @@ prepare() {
 }
 
 build() {
+  [[ "$MSYSTEM" == CLANG* ]] && export LDFLAGS="-Wl,-pdb=" # Ensures that Clang generates PDB files
+
   local -a extra_config
   extra_config+=( --disable-debug )
   mkdir -p "${srcdir}/build-${CARCH}"
@@ -79,8 +88,8 @@ build() {
   make
   case "${pkgname[@]}"
   in *pdb*)
-    cv2pdb lib/.libs/libcurl-4.dll
-    cv2pdb src/.libs/curl.exe
+    $STRIP $STRIP_OPTS lib/.libs/libcurl-4.dll
+    $STRIP $STRIP_OPTS src/.libs/curl.exe
   esac
 }
 

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -117,10 +117,18 @@ package_mingw-w64-x86_64-curl() {
   package_1
 }
 
+package_mingw-w64-clang-aarch64-curl() {
+  package_1
+}
+
 package_mingw-w64-i686-curl-pdb() {
   package_1 pdb
 }
 
 package_mingw-w64-x86_64-curl-pdb() {
+  package_1 pdb
+}
+
+package_mingw-w64-clang-aarch64-curl-pdb() {
   package_1 pdb
 }


### PR DESCRIPTION
This PR contains multiple commits with more details/explanations.

Here's the artifacts:

[mingw-w64-clang-aarch64-curl-7.86.0-1-any.pkg.tar.zip](https://github.com/git-for-windows/MINGW-packages/files/9896302/mingw-w64-clang-aarch64-curl-7.86.0-1-any.pkg.tar.zip)
