### PR TITLE
mingw-w64-git: fix git.install script on arm64

### DIFF
--- a/mingw-w64-git/git.install
+++ b/mingw-w64-git/git.install
@@ -1,8 +1,6 @@
 mingw_prefix_path () {
-	case "$(uname -m)" in
-	x86_64) echo /mingw64;;
-	i686) echo /mingw32;;
-	esac
+	test -n "$MINGW_PREFIX" || die "No MINGW_PREFIX set"
+	echo $MINGW_PREFIX
 }
 
 bin_path () {


### PR DESCRIPTION
This script was missing logic for the aarch64 architecture, resulting in the following [while experimenting](https://github.com/git-for-windows/git/discussions/4186#discussioncomment-4449439) with a `git-sdk-arm64`:

```
(1/1) installing mingw-w64-clang-aarch64-git                                 [##########################################] 100%
cp: cannot stat '/mingw64/share/git/compat-bash.exe': No such file or directory
error: command (/usr/bin/bash /usr/bin/bash -c . /tmp/alpm_2W08dr/.INSTALL; post_install 2.39.0.1.de9501c66f-1 ) failed to execute correctly
```

Since MSYS2 bash runs on x64 emulation on Windows arm64, we can't rely on `uname -m` for this architecture. Instead, let's leverage `$MINGW_PREFIX`, which is always set when `$MSYSTEM` is set.

Ref: https://www.msys2.org/wiki/arm64/
Ref: https://github.com/git-for-windows/git-sdk-64/blob/ef00fb4a0303dcb41467af8524d5b047454f331d/etc/msystem#L29
