### PR TITLE
Align libcurl with MSYS2

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -1,4 +1,4 @@
-From 5259b40b4c3cc7d2375785ff6aebf73dad751a4a Mon Sep 17 00:00:00 2001
+From fa3ce34b932e40f52b614409349be0bdef6fc197 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 22 Feb 2017 11:03:04 +0100
 Subject: [PATCH 1/2] Make cURL relocatable
@@ -16,28 +16,23 @@ versions supported by Cygwin (and therefore MSYS2).
 We also need to be extra careful to extend that path logic to the
 ca-bundle.crt used to validate HTTPS *proxies*, not only HTTPS servers.
 
-Note: we do explicitly *not* follow the rule of appending new source and
-header files to the list in Makefile.inc because that always conflicts
-with new goodies brought in by new cURL versions.
+Note: This patch relies on the `pathtools.c` and `pathtools.h` files to
+be copied from `mingw-w64-pathtools` into `lib/`.
 
 Original-patch-by: Ray Donnelly <mingw.android@gmail.com>
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
 ---
- configure.ac         |   1 +
- lib/Makefile.inc     |   2 +
- lib/curl_config.h.in |   3 +
- lib/pathtools.c      | 562 +++++++++++++++++++++++++++++++++++++++++++
- lib/pathtools.h      |  57 +++++
- lib/url.c            |  26 +-
- 6 files changed, 650 insertions(+), 1 deletion(-)
- create mode 100644 lib/pathtools.c
- create mode 100644 lib/pathtools.h
+ configure.ac         |  1 +
+ lib/Makefile.inc     |  2 ++
+ lib/curl_config.h.in |  3 +++
+ lib/url.c            | 37 +++++++++++++++++++++++++++++++++++++
+ 4 files changed, 43 insertions(+)
 
 diff --git a/configure.ac b/configure.ac
-index d4fc183ed..065fa75a6 100644
+index a889919fe..626684867 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3371,6 +3371,7 @@ dnl default includes
+@@ -3457,6 +3457,7 @@ dnl default includes
  ]
  )
  
@@ -46,10 +41,10 @@ index d4fc183ed..065fa75a6 100644
  dnl Checks for typedefs, structures, and compiler characteristics.
  AC_C_CONST
 diff --git a/lib/Makefile.inc b/lib/Makefile.inc
-index 9eafa93b9..5d2b58cbc 100644
+index 663190a19..b7d597e80 100644
 --- a/lib/Makefile.inc
 +++ b/lib/Makefile.inc
-@@ -182,6 +182,7 @@ LIB_CFILES =         \
+@@ -186,6 +186,7 @@ LIB_CFILES =         \
    noproxy.c          \
    openldap.c         \
    parsedate.c        \
@@ -57,7 +52,7 @@ index 9eafa93b9..5d2b58cbc 100644
    pingpong.c         \
    pop3.c             \
    progress.c         \
-@@ -308,6 +309,7 @@ LIB_HFILES =         \
+@@ -314,6 +315,7 @@ LIB_HFILES =         \
    nonblock.h         \
    noproxy.h          \
    parsedate.h        \
@@ -66,7 +61,7 @@ index 9eafa93b9..5d2b58cbc 100644
    pop3.h             \
    progress.h         \
 diff --git a/lib/curl_config.h.in b/lib/curl_config.h.in
-index 6c41e80e1..3a5895478 100644
+index 6d274171b..58647b5e7 100644
 --- a/lib/curl_config.h.in
 +++ b/lib/curl_config.h.in
 @@ -12,6 +12,9 @@
@@ -79,639 +74,8 @@ index 6c41e80e1..3a5895478 100644
  /* Default SSL backend */
  #undef CURL_DEFAULT_SSL_BACKEND
  
-diff --git a/lib/pathtools.c b/lib/pathtools.c
-new file mode 100644
-index 000000000..53d0db00b
---- /dev/null
-+++ b/lib/pathtools.c
-@@ -0,0 +1,562 @@
-+/*
-+      .Some useful path tools.
-+        .ASCII only for now.
-+   .Written by Ray Donnelly in 2014.
-+   .Licensed under CC0 (and anything.
-+  .else you need to license it under).
-+      .No warranties whatsoever.
-+  .email: <mingw.android@gmail.com>.
-+ */
-+
-+#if defined(__APPLE__)
-+#include <stdlib.h>
-+#else
-+#include <malloc.h>
-+#endif
-+#include <limits.h>
-+#include <stdio.h>
-+#include <string.h>
-+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
-+#include <alloca.h>
-+#endif
-+#include <unistd.h>
-+
-+/* If you don't define this, then get_executable_path()
-+   can only use argv[0] which will often not work well */
-+#define IMPLEMENT_SYS_GET_EXECUTABLE_PATH
-+
-+/* We must include these headers, otherwise free()ing the
-+   buffer returned from get_relative_path() will cause a
-+   nasty crash */
-+#include "curl_setup.h"
-+#include "curl_memory.h"
-+#include "memdebug.h"
-+
-+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
-+#if defined(__linux__)
-+/* Nothing needed, unistd.h is enough. */
-+#elif defined(__APPLE__)
-+#include <mach-o/dyld.h>
-+#elif defined(_WIN32)
-+#define WIN32_MEAN_AND_LEAN
-+#include <windows.h>
-+#include <psapi.h>
-+#endif
-+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
-+
-+#include "pathtools.h"
-+
-+char *
-+malloc_copy_string(char const * original)
-+{
-+  char * result = (char *) malloc (sizeof (char*) * strlen (original)+1);
-+  if (result != NULL)
-+  {
-+    strcpy (result, original);
-+  }
-+  return result;
-+}
-+
-+void
-+sanitise_path(char * path)
-+{
-+  size_t path_size = strlen (path);
-+
-+  /* Replace any '\' with '/' */
-+  char * path_p = path;
-+  while ((path_p = strchr (path_p, '\\')) != NULL)
-+  {
-+    *path_p = '/';
-+  }
-+  /* Replace any '//' with '/' */
-+  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
-+  while ((path_p = strstr (path_p, "//")) != NULL)
-+  {
-+    memmove (path_p, path_p + 1, path_size--);
-+  }
-+  return;
-+}
-+
-+char *
-+get_relative_path(char const * from_in, char const * to_in)
-+{
-+  size_t from_size = (from_in == NULL) ? 0 : strlen (from_in);
-+  size_t to_size = (to_in == NULL) ? 0 : strlen (to_in);
-+  size_t max_size = (from_size + to_size) * 2 + 4;
-+  char * scratch_space = (char *) alloca (from_size + 1 + to_size + 1 + max_size + max_size);
-+  char * from;
-+  char * to;
-+  char * common_part;
-+  char * result;
-+  size_t count;
-+  size_t match_size_dirsep = 0;  /* The match size up to the last /. Always wind back to this - 1 */
-+  size_t match_size = 0;         /* The running (and final) match size. */
-+  size_t largest_size;
-+  int to_final_is_slash;
-+  char from_c;
-+  char to_c;
-+  size_t ndotdots = 0;
-+  char const* from_last;
-+  size_t size_result;
-+
-+  /* No to, return "./" */
-+  if (to_in == NULL)
-+  {
-+    return malloc_copy_string ("./");
-+  }
-+
-+  /* If alloca failed or no from was given return a copy of to */
-+  if (   from_in == NULL
-+      || scratch_space == NULL )
-+  {
-+    return malloc_copy_string (to_in);
-+  }
-+
-+  from = scratch_space;
-+  strcpy (from, from_in);
-+  to = from + from_size + 1;
-+  strcpy (to, to_in);
-+  common_part = to + to_size + 1;
-+  result = common_part + max_size;
-+  simplify_path (from);
-+  simplify_path (to);
-+
-+  result[0] = '\0';
-+
-+  largest_size = (from_size > to_size) ? from_size : to_size;
-+  to_final_is_slash = (to[to_size-1] == '/') ? 1 : 0;
-+  for (match_size = 0; match_size < largest_size; ++match_size)
-+  {
-+    /* To simplify the logic, always pretend the strings end with '/' */
-+    from_c = (match_size < from_size) ? from[match_size] : '/';
-+    to_c =   (match_size <   to_size) ?   to[match_size] : '/';
-+
-+    if (from_c != to_c)
-+    {
-+      if (from_c != '\0' || to_c != '\0')
-+      {
-+        match_size = match_size_dirsep;
-+      }
-+      break;
-+    }
-+    else if (from_c == '/')
-+    {
-+      match_size_dirsep = match_size;
-+    }
-+  }
-+  strncpy (common_part, from, match_size);
-+  common_part[match_size] = '\0';
-+  from += match_size;
-+  to += match_size;
-+  from_last = from + strlen(from) - 1;
-+  while ((from = strchr (from, '/')) && from != from_last)
-+  {
-+    ++ndotdots;
-+    ++from;
-+  }
-+  for (count = 0; count < ndotdots; ++count)
-+  {
-+    strcat(result, "../");
-+  }
-+  if (strlen(to) > 0)
-+  {
-+    strcat(result, to+1);
-+  }
-+  /* Make sure that if to ends with '/' result does the same, and
-+     vice-versa. */
-+  size_result = strlen(result);
-+  if ((to_final_is_slash == 1)
-+      && (!size_result || result[size_result-1] != '/'))
-+  {
-+    strcat (result, "/");
-+  }
-+  else if (!to_final_is_slash
-+           && size_result && result[size_result-1] == '/')
-+  {
-+    result[size_result-1] = '\0';
-+  }
-+
-+  return malloc_copy_string (result);
-+}
-+
-+void
-+simplify_path(char * path)
-+{
-+  ssize_t n_toks = 1; /* in-case we need an empty initial token. */
-+  ssize_t i, j;
-+  size_t tok_size;
-+  size_t in_size = strlen (path);
-+  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
-+  char * result = path;
-+  char * result_p;
-+  char const ** toks;
-+  if (path[0] == '/' && path[1] == '/') {
-+    /* preserve UNC path */
-+    path++;
-+    in_size--;
-+    result++;
-+  }
-+  sanitise_path(result);
-+  result_p = result;
-+
-+  do
-+  {
-+    ++n_toks;
-+    ++result_p;
-+  } while ((result_p = strchr (result_p, '/')) != NULL);
-+
-+  result_p = result;
-+  toks = (char const **) alloca (sizeof (char const*) * n_toks);
-+  n_toks = 0;
-+  do
-+  {
-+    if (result_p > result)
-+    {
-+      *result_p++ = '\0';
-+    }
-+    else if (*result_p == '/')
-+    {
-+      /* A leading / creates an empty initial token. */
-+      toks[n_toks++] = result_p;
-+      *result_p++ = '\0';
-+    }
-+    toks[n_toks++] = result_p;
-+  } while ((result_p = strchr (result_p, '/')) != NULL);
-+
-+  /* Remove all non-leading '.' and any '..' we can match
-+     with an earlier forward path (i.e. neither '.' nor '..') */
-+  for (i = 1; i < n_toks; ++i)
-+  {
-+    ssize_t removals[2] = { -1, -1 };
-+    if ( strcmp (toks[i], "." ) == 0)
-+    {
-+      removals[0] = i;
-+    }
-+    else if ( strcmp (toks[i], ".." ) == 0)
-+    {
-+      /* Search backwards for a forward path to collapse.
-+         If none are found then the .. also stays. */
-+      for (j = i - 1; j > -1; --j)
-+      {
-+        if ( strcmp (toks[j], "." )
-+          && strcmp (toks[j], ".." ) )
-+        {
-+          removals[0] = j;
-+          removals[1] = i;
-+          break;
-+        }
-+      }
-+    }
-+    for (j = 0; j < 2; ++j)
-+    {
-+      if (removals[j] >= 0) /* Can become -2 */
-+      {
-+        --n_toks;
-+        memmove (&toks[removals[j]], &toks[removals[j]+1], (n_toks - removals[j])*sizeof (char*));
-+        --i;
-+        if (!j)
-+        {
-+          --removals[1];
-+        }
-+      }
-+    }
-+  }
-+  result_p = result;
-+  for (i = 0; i < n_toks; ++i)
-+  {
-+    tok_size = strlen(toks[i]);
-+    memcpy (result_p, toks[i], tok_size);
-+    result_p += tok_size;
-+    if ((!i || tok_size) && ((i < n_toks - 1) || it_ended_with_a_slash == 1))
-+    {
-+      *result_p = '/';
-+      ++result_p;
-+    }
-+  }
-+  *result_p = '\0';
-+}
-+
-+/* Returns actual_to by calculating the relative path from -> to and
-+   applying that to actual_from. An assumption that actual_from is a
-+   dir is made, and it may or may not end with a '/' */
-+char const *
-+get_relocated_path (char const * from, char const * to, char const * actual_from)
-+{
-+  char const * relative_from_to = get_relative_path (from, to);
-+  char * actual_to = (char *) malloc (strlen(actual_from) + 2 + strlen(relative_from_to));
-+  return actual_to;
-+}
-+
-+ssize_t
-+get_executable_path(char const * argv0, char * result, ssize_t max_size)
-+{
-+  char * system_result = (char *) alloca (max_size);
-+  ssize_t system_result_size = -1;
-+  ssize_t result_size = -1;
-+
-+  if (system_result != NULL)
-+  {
-+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
-+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
-+    system_result_size = readlink("/proc/self/exe", system_result, max_size);
-+#elif defined(__APPLE__)
-+    uint32_t bufsize = (uint32_t)max_size;
-+    if (_NSGetExecutablePath(system_result, &bufsize) == 0)
-+    {
-+      system_result_size = (ssize_t)bufsize;
-+    }
-+#elif defined(_WIN32)
-+    unsigned long bufsize = (unsigned long)max_size;
-+    system_result_size = GetModuleFileNameA(NULL, system_result, bufsize);
-+    if (system_result_size == 0 || system_result_size == (ssize_t)bufsize)
-+    {
-+      /* Error, possibly not enough space. */
-+      system_result_size = -1;
-+    }
-+    else
-+    {
-+      /* Early conversion to unix slashes instead of more changes
-+         everywhere else .. */
-+      char * winslash;
-+      system_result[system_result_size] = '\0';
-+      while ((winslash = strchr (system_result, '\\')) != NULL)
-+      {
-+        *winslash = '/';
-+      }
-+    }
-+#else
-+#warning "Don't know how to get executable path on this system"
-+#endif
-+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
-+  }
-+  /* Use argv0 as a default in-case of failure */
-+  if (system_result_size != -1)
-+  {
-+    strncpy (result, system_result, system_result_size);
-+    result[system_result_size] = '\0';
-+  }
-+  else
-+  {
-+    if (argv0 != NULL)
-+    {
-+      strncpy (result, argv0, max_size);
-+      result[max_size-1] = '\0';
-+    }
-+    else
-+    {
-+      result[0] = '\0';
-+    }
-+  }
-+  result_size = strlen (result);
-+  return result_size;
-+}
-+
-+#if defined(_WIN32)
-+int
-+get_dll_path(char * result, size_t max_size)
-+{
-+  HMODULE handle;
-+  char * p;
-+  int ret;
-+
-+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-+      GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-+      (void *)(uintptr_t)&get_dll_path, &handle))
-+    {
-+      return -1;
-+    }
-+
-+  ret = GetModuleFileNameA(handle, result, (DWORD)max_size);
-+  if (ret == 0 || ret == (int)max_size)
-+    {
-+      return -1;
-+    }
-+
-+  /* Early conversion to unix slashes instead of more changes
-+     everywhere else .. */
-+  result[ret] = '\0';
-+  p = result - 1;
-+  while ((p = strchr (p + 1, '\\')) != NULL)
-+    {
-+      *p = '/';
-+    }
-+
-+  return ret;
-+}
-+#endif
-+
-+char const *
-+strip_n_prefix_folders(char const * path, size_t n)
-+{
-+  char const * last = path;
-+  if (path == NULL)
-+  {
-+    return NULL;
-+  }
-+
-+  if (path[0] != '/')
-+  {
-+    return path;
-+  }
-+
-+  while (n-- && path != NULL)
-+  {
-+    last = path;
-+    path = strchr (path + 1, '/');
-+  }
-+  return (path == NULL) ? last : path;
-+}
-+
-+void
-+strip_n_suffix_folders(char * path, size_t n)
-+{
-+  if (path == NULL)
-+  {
-+    return;
-+  }
-+  while (n--)
-+  {
-+    if (strrchr (path + 1, '/'))
-+    {
-+      *strrchr (path + 1, '/') = '\0';
-+    }
-+    else
-+    {
-+      return;
-+    }
-+  }
-+  return;
-+}
-+
-+size_t
-+split_path_list(char const * path_list, char split_char, char *** arr)
-+{
-+  size_t path_count;
-+  size_t path_list_size;
-+  char const * path_list_p;
-+  char * all_memory;
-+  char const * next_path_list_p = 0;
-+
-+  path_list_p = path_list;
-+  if (path_list == NULL || path_list[0] == '\0')
-+  {
-+    return 0;
-+  }
-+  path_list_size = strlen (path_list);
-+
-+  path_count = 0;
-+  do
-+  {
-+    ++path_count;
-+    ++path_list_p;
-+  }
-+  while ((path_list_p = strchr (path_list_p, split_char)) != NULL);
-+
-+  /* allocate everything in one go. */
-+  all_memory = (char *) malloc (sizeof (char *) * path_count + strlen(path_list) + 1);
-+  if (all_memory == NULL)
-+    return 0;
-+  *arr = (char **)all_memory;
-+  all_memory += sizeof (char *) * path_count;
-+
-+  path_count = 0;
-+  path_list_p = path_list;
-+  do
-+  {
-+    size_t this_size;
-+    next_path_list_p = strchr (path_list_p, split_char);
-+    if (next_path_list_p != NULL)
-+    {
-+      ++next_path_list_p;
-+    }
-+    this_size = (next_path_list_p != NULL)
-+                       ? next_path_list_p - path_list_p - 1
-+                       : &path_list[path_list_size] - path_list_p;
-+    memcpy (all_memory, path_list_p, this_size);
-+    all_memory[this_size] = '\0';
-+    (*arr)[path_count++] = all_memory;
-+    all_memory += this_size + 1;
-+  } while ((path_list_p = next_path_list_p) != NULL);
-+
-+  return path_count;
-+}
-+
-+char *
-+get_relocated_path_list(char const * from, char const * to_path_list)
-+{
-+  char exe_path[MAX_PATH];
-+  char * temp;
-+  char **arr = NULL;
-+  char split_char = ':';
-+  size_t count;
-+  size_t result_size;
-+  size_t exe_path_size;
-+  size_t i;
-+  size_t space_required;
-+  char * scratch;
-+  char * result;
-+
-+  get_executable_path (NULL, &exe_path[0], sizeof (exe_path) / sizeof (exe_path[0]));
-+  if ((temp = strrchr (exe_path, '/')) != NULL)
-+  {
-+    temp[1] = '\0';
-+  }
-+
-+  /* Ask Alexey why he added this. Are we not 100% sure
-+     that we're dealing with unix paths here? */
-+  if (strchr (to_path_list, ';'))
-+  {
-+    split_char = ';';
-+  }
-+  count = split_path_list (to_path_list, split_char, &arr);
-+  result_size = 1 + (count - 1); /* count - 1 is for ; delim. */
-+  exe_path_size = strlen (exe_path);
-+  /* Space required is:
-+     count * (exe_path_size + strlen (rel_to_datadir))
-+     rel_to_datadir upper bound is:
-+     (count * strlen (from)) + (3 * num_slashes (from))
-+     + strlen(arr[i]) + 1.
-+     .. pathalogically num_slashes (from) is strlen (from)
-+     (from = ////////) */
-+  space_required = (count * (exe_path_size + 4 * strlen (from))) + count - 1;
-+  for (i = 0; i < count; ++i)
-+  {
-+    space_required += strlen (arr[i]);
-+  }
-+  scratch = (char *) alloca (space_required);
-+  if (scratch == NULL)
-+    return NULL;
-+  for (i = 0; i < count; ++i)
-+  {
-+    char * rel_to_datadir = get_relative_path (from, arr[i]);
-+    size_t arr_i_size;
-+    scratch[0] = '\0';
-+    arr[i] = scratch;
-+    strcat (scratch, exe_path);
-+    strcat (scratch, rel_to_datadir);
-+    simplify_path (arr[i]);
-+    arr_i_size = strlen (arr[i]);
-+    result_size += arr_i_size;
-+    scratch = arr[i] + arr_i_size + 1;
-+  }
-+  result = (char *) malloc (result_size + 1);
-+  if (result == NULL)
-+  {
-+    return NULL;
-+  }
-+  result[0] = '\0';
-+  for (i = 0; i < count; ++i)
-+  {
-+    strcat (result, arr[i]);
-+    if (i != count-1)
-+    {
-+#if defined(_WIN32)
-+      strcat (result, ";");
-+#else
-+      strcat (result, ":");
-+#endif
-+    }
-+  }
-+  free ((void*)arr);
-+  return result;
-+}
-diff --git a/lib/pathtools.h b/lib/pathtools.h
-new file mode 100644
-index 000000000..dfabfaf10
---- /dev/null
-+++ b/lib/pathtools.h
-@@ -0,0 +1,57 @@
-+/*
-+      .Some useful path tools.
-+        .ASCII only for now.
-+   .Written by Ray Donnelly in 2014.
-+   .Licensed under CC0 (and anything.
-+  .else you need to license it under).
-+      .No warranties whatsoever.
-+  .email: <mingw.android@gmail.com>.
-+ */
-+
-+#ifndef PATHTOOLS_H
-+#define PATHTOOLS_H
-+
-+#include <unistd.h>
-+#if defined(__APPLE__)
-+#include <stdlib.h>
-+#else
-+#include <malloc.h>
-+#endif
-+#include <stdio.h>
-+
-+char * malloc_copy_string(char const * original);
-+
-+/* In-place replaces any '\' with '/' and any '//' with '/' */
-+void sanitise_path(char * path);
-+
-+/* Uses a host OS specific function to determine the path of the executable,
-+   if IMPLEMENT_SYS_GET_EXECUTABLE_PATH is defined, otherwise uses argv0. */
-+ssize_t
-+get_executable_path(char const * argv0, char * result, ssize_t max_size);
-+
-+#if defined(_WIN32)
-+int get_dll_path(char * result, size_t max_size);
-+#endif
-+
-+/* Where possible, in-place removes occourances of '.' and 'path/..' */
-+void simplify_path(char * path);
-+
-+/* Allocates (via malloc) and returns the path to get from from to to. */
-+char * get_relative_path(char const * from, char const * to);
-+
-+size_t split_path_list(char const * path_list, char split_char, char *** arr);
-+
-+/* Advances path along by the amount that removes n prefix folders. */
-+char const *
-+strip_n_prefix_folders(char const * path, size_t n);
-+
-+/* NULL terminates path to remove n suffix folders. */
-+void
-+strip_n_suffix_folders(char * path, size_t n);
-+
-+char const *
-+get_relocated_path (char const * from, char const * to, char const * actual_from);
-+
-+char * get_relocated_path_list(char const * from, char const * to_path_list);
-+
-+#endif /* PATHTOOLS_H */
 diff --git a/lib/url.c b/lib/url.c
-index 3ab63a068..8eb7b524c 100644
+index f7b4bbbe9..7e9cf8ae6 100644
 --- a/lib/url.c
 +++ b/lib/url.c
 @@ -119,6 +119,9 @@
@@ -724,34 +88,29 @@ index 3ab63a068..8eb7b524c 100644
  
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
-@@ -589,12 +592,33 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
+@@ -570,21 +573,55 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
     */
    if(Curl_ssl_backend() != CURLSSLBACKEND_SCHANNEL) {
  #if defined(CURL_CA_BUNDLE)
 +#if defined(__MINGW32__)
 +    const size_t path_max = PATH_MAX;
-+    char relocated[PATH_MAX + 1], *relative;
-+    get_dll_path(relocated, path_max);
-+    strip_n_suffix_folders(relocated, 1);
-+    strncat(relocated, "/", path_max);
-+    relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
-+    strncat(relocated, relative, path_max - 1);
-+    simplify_path(relocated);
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated);
++    char relocated_bundle[path_max];
++    get_dll_path(relocated_bundle, path_max);
++    strip_n_suffix_folders(relocated_bundle, 1);
++    strncat(relocated_bundle, "/", path_max - 1);
++    char *relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
++    strncat(relocated_bundle, relative, path_max - 1);
++    free((void*)relative);
++    simplify_path(relocated_bundle);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated_bundle);
 +#else
      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], CURL_CA_BUNDLE);
--    if(result)
 +#endif /* defined(__MINGW32__) */
-+    if(result) {
-+#if defined(__MINGW32__)
-+      free((void*)relative);
-+#endif /* defined(__MINGW32__) */
+     if(result)
        return result;
-+    }
  
 +#if defined(__MINGW32__)
-+    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY], relocated);
-+    free((void*)relative);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY], relocated_bundle);
 +#else
      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE_PROXY],
                              CURL_CA_BUNDLE);
@@ -759,6 +118,29 @@ index 3ab63a068..8eb7b524c 100644
      if(result)
        return result;
  #endif
--- 
-2.39.0.windows.2
-
+ #if defined(CURL_CA_PATH)
++#if defined(__MINGW32__)
++    const size_t path_max = PATH_MAX;
++    char relocated_ca_path[path_max];
++    get_dll_path(relocated_ca_path, path_max);
++    strip_n_suffix_folders(relocated_ca_path, 1);
++    strncat(relocated_ca_path, "/", path_max - 1);
++    char *relative = get_relative_path(CURL_BINDIR, CURL_CA_PATH);
++    strncat(relocated_ca_path, relative, path_max - 1);
++    free((void*)relative);
++    simplify_path(relocated_ca_path);
++    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], relocated_ca_path);
++#else
+     result = Curl_setstropt(&set->str[STRING_SSL_CAPATH], CURL_CA_PATH);
++#endif /* defined(__MINGW32__) */
+     if(result)
+       return result;
+ 
++#if defined(__MINGW32__)
++    result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_PROXY], relocated_ca_path);
++#else
+     result = Curl_setstropt(&set->str[STRING_SSL_CAPATH_PROXY], CURL_CA_PATH);
++#endif
+     if(result)
+       return result;
+ #endif

--- a/mingw-w64-curl/0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
+++ b/mingw-w64-curl/0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
@@ -1,4 +1,4 @@
-From bb72c7849027bab8da878b41cbef3b438b0ba52f Mon Sep 17 00:00:00 2001
+From 7aec1b021f6f42cdd7bbd5d2575c7d004921db4e Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Wed, 31 Oct 2018 10:52:59 +0100
 Subject: [PATCH 2/2] Hack: make relocation work inside libexec/git-core/ and
@@ -26,45 +26,41 @@ extend the Git for Windows-specific hack with a hard-code `bin/` case.
 
 Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
 ---
- lib/url.c | 20 +++++++++++++++++++-
- 1 file changed, 19 insertions(+), 1 deletion(-)
+ lib/url.c | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/lib/url.c b/lib/url.c
-index 8eb7b524c..60c669292 100644
+index 7e9cf8ae6..77fd09a4a 100644
 --- a/lib/url.c
 +++ b/lib/url.c
-@@ -595,12 +595,30 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
- #if defined(__MINGW32__)
-     const size_t path_max = PATH_MAX;
-     char relocated[PATH_MAX + 1], *relative;
+@@ -579,10 +579,29 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
+     get_dll_path(relocated_bundle, path_max);
+     strip_n_suffix_folders(relocated_bundle, 1);
+     strncat(relocated_bundle, "/", path_max - 1);
+-    char *relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
++    char *relative;
 +    size_t len;
-     get_dll_path(relocated, path_max);
-     strip_n_suffix_folders(relocated, 1);
-     strncat(relocated, "/", path_max);
--    relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
-+    if((len = strlen(relocated)) > 18 &&
-+       !strcmp(relocated + len - 18, "/libexec/git-core/")) {
++    if((len = strlen(relocated_bundle)) > 18 &&
++       !strcmp(relocated_bundle + len - 18, "/libexec/git-core/")) {
 +      /* Hack for Git for Windows */
 +      relative = strdup("../../etc/ssl/certs/ca-bundle.crt");
-+    } else if(len > 5 && !strcmp(relocated + len - 5, "/bin/")) {
++    } else if(len > 5 && !strcmp(relocated_bundle + len - 5, "/bin/")) {
 +      /* Hack for Git for Windows */
 +      relative = strdup("../etc/ssl/certs/ca-bundle.crt");
 +    } else
 +      relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
-     strncat(relocated, relative, path_max - 1);
-     simplify_path(relocated);
-+    if (access(relocated, R_OK) != 0 &&
-+	(len = strlen(relocated)) >= 28 &&
-+	!strcmp(relocated + len - 28, "/etc/ssl/certs/ca-bundle.crt")) {
+     strncat(relocated_bundle, relative, path_max - 1);
+     free((void*)relative);
+     simplify_path(relocated_bundle);
++    if (access(relocated_bundle, R_OK) != 0 &&
++	(len = strlen(relocated_bundle)) >= 28 &&
++	!strcmp(relocated_bundle + len - 28, "/etc/ssl/certs/ca-bundle.crt")) {
 +      /* Try without /etc/ */
-+      memmove(relocated + len - 28, relocated + len - 24, 25);
-+      if (access(relocated, R_OK) != 0)
++      memmove(relocated_bundle + len - 28, relocated_bundle + len - 24, 25);
++      if (access(relocated_bundle, R_OK) != 0)
 +        /* fall back to using /etc/ */
-+        strcat(relocated + len - 28, "/etc/ssl/certs/ca-bundle.crt");
++        strcat(relocated_bundle + len - 28, "/etc/ssl/certs/ca-bundle.crt");
 +    }
-     result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated);
+     result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], relocated_bundle);
  #else
      result = Curl_setstropt(&set->str[STRING_SSL_CAFILE], CURL_CA_BUNDLE);
--- 
-2.39.0.windows.2
-

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -44,6 +44,13 @@ sha256sums=('0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0'
             'b5e23618ad6000c87b0200232578e74ef7a475e2b7e19f3949fec134d7837570')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
+if test -z "$WITHOUT_ALTERNATES"
+then
+	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-openssl-alternate")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls-alternate")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl-alternate")
+fi
+
 case "$WITHOUT_PDBS,$MSYSTEM" in
 ,CLANG*)
 	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
@@ -174,6 +181,14 @@ do_package() {
     return
   }
 
+  test alternate != "$2" || {
+    install -d -m 755 "${pkgdir}${MINGW_PREFIX}/bin"
+    infix=${1:--openssl}
+    test -winssl != $infix || infix=-schannel # the name "winssl" was ill-considered ;-)
+    install -m 755 lib/.libs/libcurl-4.dll "${pkgdir}${MINGW_PREFIX}/bin/libcurl$infix-4.dll"
+    return
+  }
+
   make DESTDIR="${pkgdir}" install
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
@@ -187,6 +202,7 @@ package_curl() {
   depends=("${depends[@]}"
            "${_cert_depends[@]}"
            "${_openssl_depends[@]}")
+  test alternate = "$1" ||
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"
              "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls")
   do_package "" "$@"
@@ -195,17 +211,21 @@ package_curl() {
 package_curl-winssl() {
   depends=("${depends[@]}"
            "${MINGW_PACKAGE_PREFIX}-libssh2-wincng")
+  test alternate = "$1" ||
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  test alternate = "$1" ||
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}"
              "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls")
   do_package -winssl "$@"
 }
 
 package_curl-gnutls() {
+  test alternate = "$1" ||
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
   depends=("${depends[@]}"
            "${_cert_depends[@]}"
            "${_gnutls_depends[@]}")
+  test alternate = "$1" ||
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}"
              "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
   do_package -gnutls "$@"
@@ -221,6 +241,18 @@ package_curl-winssl-pdb() {
 
 package_curl-gnutls-pdb() {
   package_curl-gnutls pdb
+}
+
+package_curl-openssl-alternate() {
+  package_curl alternate
+}
+
+package_curl-winssl-alternate() {
+  package_curl-winssl alternate
+}
+
+package_curl-gnutls-alternate() {
+  package_curl-gnutls alternate
 }
 
 # template start; name=mingw-w64-splitpkg-wrappers; version=1.0;

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -2,89 +2,153 @@
 
 _realname=curl
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.0.1
 pkgrel=1
-pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
+pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
-url="https://curl.haxx.se"
-license=("MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
+url="https://curl.se/"
+license=("spdx:MIT")
+_cert_depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates"
+               "${MINGW_PACKAGE_PREFIX}-libssh2")
+_openssl_depends=("${MINGW_PACKAGE_PREFIX}-openssl"
+                  "${MINGW_PACKAGE_PREFIX}-nghttp2")
+_gnutls_depends=("${MINGW_PACKAGE_PREFIX}-rtmpdump"
+                 "${MINGW_PACKAGE_PREFIX}-gnutls")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
+             "${_cert_depends[@]}"
+             "${_openssl_depends[@]}"
+             "${_gnutls_depends[@]}")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-c-ares"
+         "${MINGW_PACKAGE_PREFIX}-brotli"
          "${MINGW_PACKAGE_PREFIX}-libidn2"
          "${MINGW_PACKAGE_PREFIX}-libpsl"
-         "${MINGW_PACKAGE_PREFIX}-libssh2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-ca-certificates"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-nghttp2"
-         "${MINGW_PACKAGE_PREFIX}-brotli"
          "${MINGW_PACKAGE_PREFIX}-zstd")
 options=('staticlibs')
-source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
+source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//./_}/${_realname}-${pkgver}.tar.xz"{,.asc}
+        "pathtools.c"
+        "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
         "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch")
-sha256sums=('9b6b1e96b748d04b968786b6bdf407aa5c75ab53a3d37c1c8c81cdb736555ccf'
+sha256sums=('0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0'
             'SKIP'
-            'd8386671a7819d39bb71209f2cd255bc91c803494f26639aed6e62f42694faec'
-            'e3387326ca48c740309171063274408febb9ee0ec5de601ae77ac77b8e490999')
-validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
-              '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
-              '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
+            '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
+            '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
+            '64cbbea0a6b273b2008a08479ea8736fb4917225d434f3c08da2560318393de0'
+            'b5e23618ad6000c87b0200232578e74ef7a475e2b7e19f3949fec134d7837570')
+validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
-if [[ "$MSYSTEM" == CLANG* && -z "$WITHOUT_PDBS" ]]
-then
+case "$WITHOUT_PDBS,$MSYSTEM" in
+,CLANG*)
 	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls-pdb")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl-pdb")
 	options+=('!strip')
 	STRIP=llvm-strip
 	STRIP_OPTS=--strip-debug
-elif test -z "$WITHOUT_PDBS"
-then
+	;;
+,*)
 	pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls-pdb")
+        pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl-pdb")
 	makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
 	options+=('!strip')
 	STRIP=cv2pdb
-else
+	;;
+*)
 	options+=('strip')
-fi
+esac
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying ${_patch}"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
+}
 
 prepare() {
-  cd "${_realname}-${pkgver}"
-  # MINGW builds typically mean that prepare is run twice: once for 64-bit and
-  # once for 64-bit. These files are therefore added twice by below patches, so
-  # let's force-delete them before trying to add them.
-  rm -f lib/pathtools.h lib/pathtools.c tests/data/test2070 >/dev/null 2>&1 || true
-  patch -p1 -i "${srcdir}/0001-Make-cURL-relocatable.patch"
-  patch -p1 -i "${srcdir}/0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch"
+  test ! -d "${startdir}/../mingw-w64-pathtools" || {
+    cmp "${startdir}/../mingw-w64-pathtools/pathtools.c" "${srcdir}/pathtools.c" &&
+    cmp "${startdir}/../mingw-w64-pathtools/pathtools.h" "${srcdir}/pathtools.h"
+  } || exit 1
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+  cp -fHv "${srcdir}"/pathtools.[ch] lib/
+
+  apply_patch_with_msg \
+    0001-Make-cURL-relocatable.patch \
+    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
+
   autoreconf -vfi
 }
 
-build() {
-  [[ "$MSYSTEM" == CLANG* ]] && export LDFLAGS="-Wl,-pdb=" # Ensures that Clang generates PDB files
-
+do_build() {
+  _variant=$1
+  _destdir="${srcdir}/build-${MSYSTEM}"
+  if [ "${_variant}" != "-openssl" ]; then
+    _destdir="${_destdir}${_variant}"
+  fi
   local -a extra_config
-  extra_config+=( --disable-debug )
-  mkdir -p "${srcdir}/build-${CARCH}"
-  extra_config+=("--with-ssl")
-  extra_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
-  extra_config+=('--with-nghttp2=${MINGW_PREFIX}/')
-  extra_config+=("--with-schannel")
-  cd "${srcdir}/build-${CARCH}"
+  if check_option "debug" "y"; then
+    extra_config+=( --enable-debug )
+  else
+    extra_config+=( --disable-debug )
+  fi
+
+  local -a _variant_config
+  if [ "${_variant}" = "-winssl" ]; then
+    _variant_config+=("--with-schannel")
+    _variant_config+=('--without-nghttp2')
+    _variant_config+=("--without-ca-bundle")
+    _variant_config+=("--without-ca-path")
+    _variant_config+=("--without-librtmp")
+  elif [ "${_variant}" = "-gnutls" ]; then
+    _variant_config+=("--with-default-ssl-backend=gnutls")
+    _variant_config+=("--with-gnutls")
+    _variant_config+=("--with-schannel")
+    _variant_config+=('--without-nghttp2')
+    _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/etc/ssl/certs/ca-bundle.crt")
+    _variant_config+=("--with-librtmp")
+  elif [ "${_variant}" = "-openssl" ]; then
+    _variant_config+=("--with-default-ssl-backend=openssl")
+    _variant_config+=("--with-openssl")
+    _variant_config+=("--with-schannel")
+    _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/etc/ssl/certs/ca-bundle.crt")
+    _variant_config+=("--with-nghttp2=${MINGW_PREFIX}")
+    _variant_config+=("--without-librtmp")
+  fi
+
+  case "$MSYSTEM" in CLANG*) export LDFLAGS="-Wl,-pdb=";; esac # Ensures that Clang generates PDB files
+
+  msg2 "Building shared library"
+  mkdir -p "${_destdir}-shared" && cd "${_destdir}-shared"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
+    --disable-pthreads \
     --without-random \
-    --without-librtmp \
-    --enable-static \
+    --disable-static \
     --enable-shared \
     --enable-sspi \
+    --enable-ldap \
+    --enable-ldaps \
+    --with-brotli \
+    --with-ldap-lib=wldap32 \
     --with-libssh2 \
+    --with-zstd \
+    "${_variant_config[@]}" \
     "${extra_config[@]}"
 # there's a bug with zsh completion generation script and Windows.
-# curl has to specified with the file extension.
+# curl has to be specified with the file extension.
   sed -i "s|\/curl > \$\@|\/curl\$\{EXEEXT\} > \$\@|" scripts/Makefile
   make
   case "${pkgname[@]}"
@@ -94,10 +158,16 @@ build() {
   esac
 }
 
-package_1() {
-  cd "${srcdir}/build-${CARCH}"
+build() {
+  do_build -openssl
+  do_build -winssl
+  do_build -gnutls
+}
 
-  test pdb != "$1" || {
+do_package() {
+  cd "${srcdir}/build-${MSYSTEM}$1-shared"
+
+  test pdb != "$2" || {
     install -d -m 755 "${pkgdir}${MINGW_PREFIX}/bin"
     install -m 755 lib/.libs/libcurl-4.pdb "${pkgdir}${MINGW_PREFIX}/bin"
     install -m 755 src/.libs/curl.pdb "${pkgdir}${MINGW_PREFIX}/bin"
@@ -108,28 +178,58 @@ package_1() {
 
   local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/bin/curl-config
+  sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libcurl.pc
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }
 
-package_mingw-w64-i686-curl() {
-  package_1
+package_curl() {
+  depends=("${depends[@]}"
+           "${_cert_depends[@]}"
+           "${_openssl_depends[@]}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"
+             "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls")
+  do_package "" "$@"
 }
 
-package_mingw-w64-x86_64-curl() {
-  package_1
+package_curl-winssl() {
+  depends=("${depends[@]}"
+           "${MINGW_PACKAGE_PREFIX}-libssh2-wincng")
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+             "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls")
+  do_package -winssl "$@"
 }
 
-package_mingw-w64-clang-aarch64-curl() {
-  package_1
+package_curl-gnutls() {
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  depends=("${depends[@]}"
+           "${_cert_depends[@]}"
+           "${_gnutls_depends[@]}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+             "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
+  do_package -gnutls "$@"
 }
 
-package_mingw-w64-i686-curl-pdb() {
-  package_1 pdb
+package_curl-pdb() {
+  package_curl pdb
 }
 
-package_mingw-w64-x86_64-curl-pdb() {
-  package_1 pdb
+package_curl-winssl-pdb() {
+  package_curl-winssl pdb
 }
 
-package_mingw-w64-clang-aarch64-curl-pdb() {
-  package_1 pdb
+package_curl-gnutls-pdb() {
+  package_curl-gnutls pdb
 }
+
+# template start; name=mingw-w64-splitpkg-wrappers; version=1.0;
+# vim: set ft=bash :
+
+# generate wrappers
+for _name in "${pkgname[@]}"; do
+  _short="package_${_name#${MINGW_PACKAGE_PREFIX}-}"
+  _func="$(declare -f "${_short}")"
+  eval "${_func/#${_short}/package_${_name}}"
+done
+# template end;

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -205,6 +205,28 @@ package_curl() {
   test alternate = "$1" ||
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl"
              "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls")
+
+  # (Temporarily) force git-sdk-* to switch to the mingw-w64-curl-winssl
+  # package because that package does not depend on OpenSSL, allowing Git for
+  # Windows to upgrade to OpenSSL v3.* (which would otherwise break libcurl,
+  # and therefore `git clone`, and therefore Git for Windows' SDK
+  # synchronization, because that upgrade changes the OpenSSL DLL's file name).
+  #
+  # To allow Git's `http.sslBackend=openssl` to work, still, this code block
+  # _actually_ overrides the `mingw-w64-curl` package with the
+  # `-openssl-alternate` variant, and letting that variant depend on the
+  # `-winssl` one. This effectively "force-upgrades" mingw-w64-curl with
+  # mingw-w64-curl-winssl and mingw-w64-curl-openssl-alternate.
+  #
+  # The plan is to remove this override after Git for Windows' SDK has upgraded
+  # to OpenSSL v3.* (the current idea being to do that about a week after Git
+  # for Windows v2.41.0 has been released, i.e. to wait for a sort-of-idle
+  # time).
+  test alternate != "$*" || {
+    depends+=("${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
+    replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  }
+
   do_package "" "$@"
 }
 

--- a/mingw-w64-curl/pathtools.c
+++ b/mingw-w64-curl/pathtools.c
@@ -1,0 +1,627 @@
+/*
+      .Some useful path tools.
+        .ASCII only for now.
+   .Written by Ray Donnelly in 2014.
+   .Licensed under CC0 (and anything.
+  .else you need to license it under).
+      .No warranties whatsoever.
+  .email: <mingw.android@gmail.com>.
+ */
+
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+#include <alloca.h>
+#endif
+#include <unistd.h>
+
+/* If you don't define this, then get_executable_path()
+   can only use argv[0] which will often not work well */
+#define IMPLEMENT_SYS_GET_EXECUTABLE_PATH
+
+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+/* Nothing needed, unistd.h is enough. */
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(_WIN32)
+#define WIN32_MEAN_AND_LEAN
+#include <windows.h>
+#include <psapi.h>
+#endif
+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
+
+#include "pathtools.h"
+
+char *
+malloc_copy_string(char const * original)
+{
+  char * result = (char *) malloc (sizeof (char*) * strlen (original)+1);
+  if (result != NULL)
+  {
+    strcpy (result, original);
+  }
+  return result;
+}
+
+void
+sanitise_path(char * path)
+{
+  size_t path_size = strlen (path);
+
+  /* Replace any '\' with '/' */
+  char * path_p = path;
+  while ((path_p = strchr (path_p, '\\')) != NULL)
+  {
+    *path_p = '/';
+  }
+  /* Replace any '//' with '/' */
+  path_p = path + !!*path; /* skip first character, if any, to handle UNC paths correctly */
+  while ((path_p = strstr (path_p, "//")) != NULL)
+  {
+    memmove (path_p, path_p + 1, path_size--);
+  }
+  return;
+}
+
+char *
+get_relative_path(char const * from_in, char const * to_in)
+{
+  size_t from_size = (from_in == NULL) ? 0 : strlen (from_in);
+  size_t to_size = (to_in == NULL) ? 0 : strlen (to_in);
+  size_t max_size = (from_size + to_size) * 2 + 4;
+  char * scratch_space = (char *) alloca (from_size + 1 + to_size + 1 + max_size + max_size);
+  char * from;
+  char * to;
+  char * common_part;
+  char * result;
+  size_t count;
+
+  /* No to, return "./" */
+  if (to_in == NULL)
+  {
+    return malloc_copy_string ("./");
+  }
+
+  /* If alloca failed or no from was given return a copy of to */
+  if (   from_in == NULL
+      || scratch_space == NULL )
+  {
+    return malloc_copy_string (to_in);
+  }
+
+  from = scratch_space;
+  strcpy (from, from_in);
+  to = from + from_size + 1;
+  strcpy (to, to_in);
+  common_part = to + to_size + 1;
+  result = common_part + max_size;
+  simplify_path (from);
+  simplify_path (to);
+
+  result[0] = '\0';
+
+  size_t match_size_dirsep = 0;  /* The match size up to the last /. Always wind back to this - 1 */
+  size_t match_size = 0;         /* The running (and final) match size. */
+  size_t largest_size = (from_size > to_size) ? from_size : to_size;
+  int to_final_is_slash = (to[to_size-1] == '/') ? 1 : 0;
+  char from_c;
+  char to_c;
+  for (match_size = 0; match_size < largest_size; ++match_size)
+  {
+    /* To simplify the logic, always pretend the strings end with '/' */
+    from_c = (match_size < from_size) ? from[match_size] : '/';
+    to_c =   (match_size <   to_size) ?   to[match_size] : '/';
+
+    if (from_c != to_c)
+    {
+      if (from_c != '\0' || to_c != '\0')
+      {
+        match_size = match_size_dirsep;
+      }
+      break;
+    }
+    else if (from_c == '/')
+    {
+      match_size_dirsep = match_size;
+    }
+  }
+  strncpy (common_part, from, match_size);
+  common_part[match_size] = '\0';
+  from += match_size;
+  to += match_size;
+  size_t ndotdots = 0;
+  char const* from_last = from + strlen(from) - 1;
+  while ((from = strchr (from, '/')) && from != from_last)
+  {
+    ++ndotdots;
+    ++from;
+  }
+  for (count = 0; count < ndotdots; ++count)
+  {
+    strcat(result, "../");
+  }
+  if (strlen(to) > 0)
+  {
+    strcat(result, to+1);
+  }
+  /* Make sure that if to ends with '/' result does the same, and
+     vice-versa. */
+  size_t size_result = strlen(result);
+  if ((to_final_is_slash == 1)
+      && (!size_result || result[size_result-1] != '/'))
+  {
+    strcat (result, "/");
+  }
+  else if (!to_final_is_slash
+           && size_result && result[size_result-1] == '/')
+  {
+    result[size_result-1] = '\0';
+  }
+
+  return malloc_copy_string (result);
+}
+
+void
+simplify_path(char * path)
+{
+  ssize_t n_toks = 1; /* in-case we need an empty initial token. */
+  ssize_t i, j;
+  size_t tok_size;
+  size_t in_size = strlen (path);
+  int it_ended_with_a_slash = (path[in_size - 1] == '/') ? 1 : 0;
+  char * result = path;
+  if (path[0] == '/' && path[1] == '/') {
+    /* preserve UNC path */
+    path++;
+    in_size--;
+    result++;
+  }
+  sanitise_path(result);
+  char * result_p = result;
+
+  do
+  {
+    ++n_toks;
+    ++result_p;
+  } while ((result_p = strchr (result_p, '/')) != NULL);
+
+  result_p = result;
+  char const ** toks = (char const **) alloca (sizeof (char const*) * n_toks);
+  n_toks = 0;
+  do
+  {
+    if (result_p > result)
+    {
+      *result_p++ = '\0';
+    }
+    else if (*result_p == '/')
+    {
+      /* A leading / creates an empty initial token. */
+      toks[n_toks++] = result_p;
+      *result_p++ = '\0';
+    }
+    toks[n_toks++] = result_p;
+  } while ((result_p = strchr (result_p, '/')) != NULL);
+
+  /* Remove all non-leading '.' and any '..' we can match
+     with an earlier forward path (i.e. neither '.' nor '..') */
+  for (i = 1; i < n_toks; ++i)
+  {
+    int removals[2] = { -1, -1 };
+    if ( strcmp (toks[i], "." ) == 0)
+    {
+      removals[0] = i;
+    }
+    else if ( strcmp (toks[i], ".." ) == 0)
+    {
+      /* Search backwards for a forward path to collapse.
+         If none are found then the .. also stays. */
+      for (j = i - 1; j > -1; --j)
+      {
+        if ( strcmp (toks[j], "." )
+          && strcmp (toks[j], ".." ) )
+        {
+          removals[0] = j;
+          removals[1] = i;
+          break;
+        }
+      }
+    }
+    for (j = 0; j < 2; ++j)
+    {
+      if (removals[j] >= 0) /* Can become -2 */
+      {
+        --n_toks;
+        memmove (&toks[removals[j]], &toks[removals[j]+1], (n_toks - removals[j])*sizeof (char*));
+        --i;
+        if (!j)
+        {
+          --removals[1];
+        }
+      }
+    }
+  }
+  result_p = result;
+  for (i = 0; i < n_toks; ++i)
+  {
+    tok_size = strlen(toks[i]);
+    memmove (result_p, toks[i], tok_size);
+    result_p += tok_size;
+    if ((!i || tok_size) && ((i < n_toks - 1) || it_ended_with_a_slash == 1))
+    {
+      *result_p = '/';
+      ++result_p;
+    }
+  }
+  *result_p = '\0';
+}
+
+int
+get_executable_path(char const * argv0, char * result, ssize_t max_size)
+{
+  char * system_result = (char *) alloca (max_size);
+  ssize_t system_result_size = -1;
+  ssize_t result_size = -1;
+
+  if (system_result != NULL)
+  {
+#if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
+    system_result_size = readlink("/proc/self/exe", system_result, max_size);
+#elif defined(__APPLE__)
+    uint32_t bufsize = (uint32_t)max_size;
+    if (_NSGetExecutablePath(system_result, &bufsize) == 0)
+    {
+      system_result_size = (ssize_t)bufsize;
+    }
+#elif defined(_WIN32)
+    unsigned long bufsize = (unsigned long)max_size;
+    system_result_size = GetModuleFileNameA(NULL, system_result, bufsize);
+    if (system_result_size == 0 || system_result_size == (ssize_t)bufsize)
+    {
+      /* Error, possibly not enough space. */
+      system_result_size = -1;
+    }
+    else
+    {
+      /* Early conversion to unix slashes instead of more changes
+         everywhere else .. */
+      char * winslash;
+      system_result[system_result_size] = '\0';
+      while ((winslash = strchr (system_result, '\\')) != NULL)
+      {
+        *winslash = '/';
+      }
+    }
+#else
+#warning "Don't know how to get executable path on this system"
+#endif
+#endif /* defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH) */
+  }
+  /* Use argv0 as a default in-case of failure */
+  if (system_result_size != -1)
+  {
+    strncpy (result, system_result, system_result_size);
+    result[system_result_size] = '\0';
+  }
+  else
+  {
+    if (argv0 != NULL)
+    {
+      strncpy (result, argv0, max_size);
+      result[max_size-1] = '\0';
+    }
+    else
+    {
+      result[0] = '\0';
+    }
+  }
+  result_size = strlen (result);
+  return result_size;
+}
+
+#if defined(_WIN32)
+int
+get_dll_path(char * result, unsigned long max_size)
+{
+  HMODULE handle;
+  char * p;
+  int ret;
+
+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+      GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+      (LPCSTR) &get_dll_path, &handle))
+    {
+      return -1;
+    }
+
+  ret = GetModuleFileNameA(handle, result, max_size);
+  if (ret == 0 || ret == (int)max_size)
+    {
+      return -1;
+    }
+
+  /* Early conversion to unix slashes instead of more changes
+     everywhere else .. */
+  result[ret] = '\0';
+  p = result - 1;
+  while ((p = strchr (p + 1, '\\')) != NULL)
+    {
+      *p = '/';
+    }
+
+  return ret;
+}
+#endif
+
+char const *
+strip_n_prefix_folders(char const * path, size_t n)
+{
+  if (path == NULL)
+  {
+    return NULL;
+  }
+
+  if (path[0] != '/')
+  {
+    return path;
+  }
+
+  char const * last = path;
+  while (n-- && path != NULL)
+  {
+    last = path;
+    path = strchr (path + 1, '/');
+  }
+  return (path == NULL) ? last : path;
+}
+
+void
+strip_n_suffix_folders(char * path, size_t n)
+{
+  if (path == NULL)
+  {
+    return;
+  }
+  while (n--)
+  {
+    if (strrchr (path + 1, '/'))
+    {
+      *strrchr (path + 1, '/') = '\0';
+    }
+    else
+    {
+      return;
+    }
+  }
+  return;
+}
+
+size_t
+split_path_list(char const * path_list, char split_char, char *** arr)
+{
+  size_t path_count;
+  size_t path_list_size;
+  char const * path_list_p;
+
+  path_list_p = path_list;
+  if (path_list == NULL || path_list[0] == '\0')
+  {
+    return 0;
+  }
+  path_list_size = strlen (path_list);
+
+  path_count = 0;
+  do
+  {
+    ++path_count;
+    ++path_list_p;
+  }
+  while ((path_list_p = strchr (path_list_p, split_char)) != NULL);
+
+  /* allocate everything in one go. */
+  char * all_memory = (char *) malloc (sizeof (char *) * path_count + strlen(path_list) + 1);
+  if (all_memory == NULL)
+    return 0;
+  *arr = (char **)all_memory;
+  all_memory += sizeof (char *) * path_count;
+
+  path_count = 0;
+  path_list_p = path_list;
+  char const * next_path_list_p = 0;
+  do
+  {
+    next_path_list_p = strchr (path_list_p, split_char);
+    if (next_path_list_p != NULL)
+    {
+      ++next_path_list_p;
+    }
+    size_t this_size = (next_path_list_p != NULL)
+                       ? next_path_list_p - path_list_p - 1
+                       : &path_list[path_list_size] - path_list_p;
+    memcpy (all_memory, path_list_p, this_size);
+    all_memory[this_size] = '\0';
+    (*arr)[path_count++] = all_memory;
+    all_memory += this_size + 1;
+  } while ((path_list_p = next_path_list_p) != NULL);
+
+  return path_count;
+}
+
+static char *
+get_relocated_path_list_ref(char const * from, char const * to_path_list, char *ref_path)
+{
+  char * temp;
+  if ((temp = strrchr (ref_path, '/')) != NULL)
+  {
+    temp[1] = '\0';
+  }
+
+  char **arr = NULL;
+  /* Ask Alexey why he added this. Are we not 100% sure
+     that we're dealing with unix paths here? */
+  char split_char = ':';
+  if (strchr (to_path_list, ';'))
+  {
+    split_char = ';';
+  }
+  size_t count = split_path_list (to_path_list, split_char, &arr);
+  int result_size = 1 + (count - 1); /* count - 1 is for ; delim. */
+  size_t ref_path_size = strlen (ref_path);
+  size_t i;
+  /* Space required is:
+     count * (ref_path_size + strlen (rel_to_datadir))
+     rel_to_datadir upper bound is:
+     (count * strlen (from)) + (3 * num_slashes (from))
+     + strlen(arr[i]) + 1.
+     .. pathalogically num_slashes (from) is strlen (from)
+     (from = ////////) */
+  size_t space_required = (count * (ref_path_size + 4 * strlen (from))) + count - 1;
+  for (i = 0; i < count; ++i)
+  {
+    space_required += strlen (arr[i]);
+  }
+  char * scratch = (char *) alloca (space_required);
+  if (scratch == NULL)
+    return NULL;
+  for (i = 0; i < count; ++i)
+  {
+    char * rel_to_datadir = get_relative_path (from, arr[i]);
+    scratch[0] = '\0';
+    arr[i] = scratch;
+    strcat (scratch, ref_path);
+    strcat (scratch, rel_to_datadir);
+    free (rel_to_datadir);
+    simplify_path (arr[i]);
+    size_t arr_i_size = strlen (arr[i]);
+    result_size += arr_i_size;
+    scratch = arr[i] + arr_i_size + 1;
+  }
+  char * result = (char *) malloc (result_size);
+  if (result == NULL)
+  {
+    return NULL;
+  }
+  result[0] = '\0';
+  for (i = 0; i < count; ++i)
+  {
+    strcat (result, arr[i]);
+    if (i != count-1)
+    {
+#if defined(_WIN32)
+      strcat (result, ";");
+#else
+      strcat (result, ":");
+#endif
+    }
+  }
+  free ((void*)arr);
+  return result;
+}
+
+char *
+get_relocated_path_list(char const *from, char const *to_path_list)
+{
+  char exe_path[MAX_PATH];
+  get_executable_path (NULL, &exe_path[0], sizeof (exe_path) / sizeof (exe_path[0]));
+
+  return get_relocated_path_list_ref(from, to_path_list, exe_path);
+}
+
+char *
+get_relocated_path_list_lib(char const *from, char const *to_path_list)
+{
+  char dll_path[PATH_MAX];
+  get_dll_path (&dll_path[0], sizeof(dll_path)/sizeof(dll_path[0]));
+
+  return get_relocated_path_list_ref(from, to_path_list, dll_path);
+}
+
+static char *
+single_path_relocation_ref(const char *from, const char *to, char *ref_path)
+{
+#if defined(__MINGW32__)
+  if (strrchr (ref_path, '/') != NULL)
+  {
+     strrchr (ref_path, '/')[1] = '\0';
+  }
+  char * rel_to_datadir = get_relative_path (from, to);
+  strcat (ref_path, rel_to_datadir);
+  free (rel_to_datadir);
+  simplify_path (&ref_path[0]);
+  return malloc_copy_string(ref_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char *
+single_path_relocation(const char *from, const char *to)
+{
+#if defined(__MINGW32__)
+  char exe_path[PATH_MAX];
+  get_executable_path (NULL, &exe_path[0], sizeof(exe_path)/sizeof(exe_path[0]));
+  return single_path_relocation_ref(from, to, exe_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char *
+single_path_relocation_lib(const char *from, const char *to)
+{
+#if defined(__MINGW32__)
+  char dll_path[PATH_MAX];
+  get_dll_path (&dll_path[0], sizeof(dll_path)/sizeof(dll_path[0]));
+  return single_path_relocation_ref(from, to, dll_path);
+#else
+  return malloc_copy_string(to);
+#endif
+}
+
+char *
+pathlist_relocation(const char *from_path, const char *to_path_list)
+{
+#if defined(__MINGW32__)
+  static char stored_path[PATH_MAX];
+  static int stored = 0;
+  if (stored == 0)
+  {
+    char const * relocated = get_relocated_path_list(from_path, to_path_list);
+    strncpy (stored_path, relocated, PATH_MAX);
+    stored_path[PATH_MAX-1] = '\0';
+    free ((void *)relocated);
+    stored = 1;
+  }
+  return stored_path;
+#else
+  return (to_path_list);
+#endif
+}
+
+char *
+pathlist_relocation_lib(const char *from_path, const char *to_path_list)
+{
+#if defined(__MINGW32__)
+  static char stored_path[PATH_MAX];
+  static int stored = 0;
+  if (stored == 0)
+  {
+    char const * relocated = get_relocated_path_list_lib(from_path, to_path_list);
+    strncpy (stored_path, relocated, PATH_MAX);
+    stored_path[PATH_MAX-1] = '\0';
+    free ((void *)relocated);
+    stored = 1;
+  }
+  return stored_path;
+#else
+  return (to_path_list);
+#endif
+}

--- a/mingw-w64-curl/pathtools.h
+++ b/mingw-w64-curl/pathtools.h
@@ -1,0 +1,59 @@
+/*
+      .Some useful path tools.
+        .ASCII only for now.
+   .Written by Ray Donnelly in 2014.
+   .Licensed under CC0 (and anything.
+  .else you need to license it under).
+      .No warranties whatsoever.
+  .email: <mingw.android@gmail.com>.
+ */
+
+#ifndef PATHTOOLS_H
+#define PATHTOOLS_H
+
+#include <unistd.h>
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
+#include <malloc.h>
+#endif
+#include <stdio.h>
+
+char * malloc_copy_string(char const * original);
+
+/* In-place replaces any '\' with '/' and any '//' with '/' */
+void sanitise_path(char * path);
+
+/* Uses a host OS specific function to determine the path of the executable,
+   if IMPLEMENT_SYS_GET_EXECUTABLE_PATH is defined, otherwise uses argv0. */
+int get_executable_path(char const * argv0, char * result, ssize_t max_size);
+
+#if defined(_WIN32)
+int get_dll_path(char * result, unsigned long max_size);
+#endif
+
+/* Where possible, in-place removes occourances of '.' and 'path/..' */
+void simplify_path(char * path);
+
+/* Allocates (via malloc) and returns the path to get from from to to. */
+char * get_relative_path(char const * from, char const * to);
+
+size_t split_path_list(char const * path_list, char split_char, char *** arr);
+
+/* Advances path along by the amount that removes n prefix folders. */
+char const *
+strip_n_prefix_folders(char const * path, size_t n);
+
+/* NULL terminates path to remove n suffix folders. */
+void
+strip_n_suffix_folders(char * path, size_t n);
+
+char * get_relocated_path_list(char const * from, char const * to_path_list);
+char * get_relocated_path_list_lib(char const * from, char const * to_path_list);
+
+char * single_path_relocation(const char *from, const char *to);
+char * single_path_relocation_lib(const char *from, const char *to);
+char * pathlist_relocation(const char *from_path, const char *to_path_list);
+char * pathlist_relocation_lib(const char *from_path, const char *to_path_list);
+
+#endif /* PATHTOOLS_H */


### PR DESCRIPTION
Years ago, I taught libcurl the trick to include multiple SSL/TLS backends, and then I taught Git for Windows to have a run-time option to choose between those. This allowed users relying on OpenSSL (e.g. because they read somewhere on the internet that you need OpenSSL to be able to access Git repositories on hosts with self-signed certificates) but also offering to rely on Secure Channel to handle https:// URLs.

However, this now comes back to bite me.

As per https://github.com/git-for-windows/git/issues/4350#issuecomment-1485041503, the major block for upgrading Git for Windows' OpenSSL from v1.1 to v3 is the tricky part where such an upgrade would break `git fetch`/`git clone` and `git push` because the libcurl depends on the OpenSSL DLL, and the major version bump will _change_ the file name of said DLL.

To overcome that, the plan is to build libcurl flavors for each supported SSL/TLS backend, aligning with the way MSYS2 builds libcurl, then switch Git for Windows' SDK to the Secure Channel-flavored libcurl, and teach Git to look for the specific flavor of libcurl corresponding to the `http.sslBackend` setting (if that was configured).

https://github.com/git-for-windows/git/pull/4410 teaches Git that trick, and this here PR changes the package definition so that those libcurl flavors are built.

To make full use of the feature implemented in https://github.com/git-for-windows/git/pull/4410, with this PR we also build "alternate" packages (e.g. `mingw-w64-libcurl-openssl-alternate`) that have the same dependencies as the regular `mingw-w64-libcurl` packages, but do not conflict with them and only install the DLL with a name that `git.exe` will now look for.