### PR TITLE
git: offer `/cmd/git-receive.exe` and `git-upload-pack.exe`

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -68,7 +68,7 @@ sha256sums=('SKIP'
             'db754d6fe6722ad54d43df15ee93b1d9cead406158ed84dcbf35e5b4225469ed'
             'db754d6fe6722ad54d43df15ee93b1d9cead406158ed84dcbf35e5b4225469ed'
             'cbed8b133eb9eec9972f146be5c3ff49db29b2fff8ab9c87a6d0c646c08a5128'
-            '595c3af0b17de8e0b042531d716448ecf4b27bd5d36a8ac46829d05ce4d2c9d5'
+            'f54dec5925a67c47d3b87a23cea6e370c3f38e61d3301860b725f29801c99bb0'
             '7413506c59d25621e475aa45447993748332c72cfbb4cf94cce6bee6f1218a09'
             '6d83e1cb1acdb6eb1f2d5cb9299298e57680f5ca43d43c3e67c9da17f21b9b01')
 
@@ -175,6 +175,7 @@ build() {
   make -f ../mingw-w64-git.mak git-wrapper.exe \
 	git-bash.exe git-cmd.exe compat-bash.exe \
 	cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
+	cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
 	edit-git-bash.exe &&
   rm -f *.res &&
 
@@ -249,6 +250,7 @@ package_git () {
   # Install Git wrapper into /cmd/
   install -d -m755 $pkgdir/cmd
   install -m755 cmd/git.exe cmd/gitk.exe cmd/git-gui.exe \
+	cmd/git-receive-pack.exe cmd/git-upload-pack.exe \
 	../start-ssh-agent.cmd ../start-ssh-pageant.cmd \
 	$pkgdir/cmd
 

--- a/mingw-w64-git/mingw-w64-git.mak
+++ b/mingw-w64-git/mingw-w64-git.mak
@@ -19,7 +19,7 @@ git-bash.exe git-cmd.exe compat-bash.exe: %.exe: %.res
 cmd/gitk.exe cmd/git-gui.exe: gitk.res
 
 git-bash.exe git-cmd.exe compat-bash.exe \
-cmd/git.exe cmd/gitk.exe cmd/git-gui.exe: \
+cmd/git.exe cmd/git-receive-pack.exe cmd/git-upload-pack.exe cmd/gitk.exe cmd/git-gui.exe: \
 		%.exe: git-wrapper.o git.res
 	@mkdir -p cmd
 	$(QUIET_LINK)$(CC) $(ALL_LDFLAGS) $(COMPAT_CFLAGS) -o $@ $^ -lshlwapi
@@ -38,7 +38,7 @@ print-builtins:
 strip-all: strip
 	$(STRIP) $(STRIP_OPTS) \
 		contrib/credential/wincred/git-credential-wincred.exe \
-		cmd/git{,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
+		cmd/git{,-receive-pack,-upload-pack,-gui,k}.exe compat-bash.exe git-{bash,cmd,wrapper}.exe
 
 install-pdbs:
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(bindir_SQ)'


### PR DESCRIPTION
Now that [the Git wrapper can impersonate `git-receive-pack.exe` when installed into `/cmd/`](https://github.com/git-for-windows/MINGW-packages/pull/85), redirecting to the actual executable, let's do so.

This allows Git for Windows to serve repositories via SSH when [running the corresponding Windows service](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration) as long as Git for Windows' `/cmd/` directory is in the `PATH`.

This fixes https://github.com/git-for-windows/git/issues/4359.