### PR TITLE
ARM64: fix `/bin/bash.exe` and `/bin/sh.exe` not starting

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -9,7 +9,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 	 "${MINGW_PACKAGE_PREFIX}-${_realname}-test-artifacts")
 tag=2.42.0.windows.2
 pkgver=2.42.0.2.2f819d1670
-pkgrel=1
+pkgrel=2
 pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('any')
 url="https://git-for-windows.github.io/"
@@ -61,7 +61,7 @@ sha256sums=('SKIP'
             'a9dcba5aebc93ae7aacdee03275780fc6c0f15e88fda30c93041e75851e75090'
             'f16b345aba17acd124ab5940635dfa2d87445df73eedbeb80e0285f29c85415a'
             '80b0b11efe5a2f9b4cd92f28c260d0b3aad8b809c34ed95237c59b73e08ade0b'
-            'a5722c42c4b6c1e11ffb940d8c8f04956bb40c050c92f1c3f604145252679279'
+            '20613488bbd66bced2ef786448dc335c9cc7a5ef8be800e0d5bab83e36faf584'
             'dab3e41e935a33f443a4ff4ef4ce92c191b6d952d9eb37e14885540ad5af99ed'
             'c975292adae1f2666f07f8ee9b7d50576da249d9151c6bd211602adc8d37b6ab'
             '53e630f581bee400100d074189754413afb6670ba1c09a5a3a09c5b575e41e60'


### PR DESCRIPTION
There is a long standing known issue in @dennisameling test builds

> When using the installer and selecting the "Add a Git Bash Profile to Windows Terminal" option, the profile is added to Windows Terminal, but it crashes on launch.

Turns out it's a caching issue.