### PR TITLE
mingw-w64-asciidoctor-extensions: add arm64 support

### DIFF
--- a/mingw-w64-asciidoctor-extensions/PKGBUILD
+++ b/mingw-w64-asciidoctor-extensions/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=asciidoctor-extensions
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=150.9846486
+pkgver=246.42e366e
 pkgrel=1
 pkgdesc="This package installs asciidoctor plus extensions."
 url="https://github.com/asciidoctor/asciidoctor"
@@ -28,6 +28,9 @@ i686)
   ;;
 x86_64)
   LIBDIR="/mingw64/lib/${_realname}"
+  ;;
+aarch64)
+  LIBDIR="/clangarm64/lib/${_realname}"
   ;;
 esac
 


### PR DESCRIPTION
Ruby support was added to clangarm64 in November 2023, so we can now enable asciidoctor-extensions on ARM64 as well. This is needed for building the mingw-w64-git package.

Ref: https://github.com/msys2/MINGW-packages/pull/19179