### PR TITLE
mingw-w64-git: switch to asciidoctor and enable arm64 for it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,24 @@ jobs:
           # reduce time required to install packages by disabling pacman's disk space checking
           sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf &&
 
+          # help git-sdk-arm64 switch from `asciidoc` to `asciidoctor`
+          if test mingw-w64-git = '${{ matrix.directory }}'
+          then
+            packages=$(ls -d /var/lib/pacman/local/mingw-w64-*-asciidoctor-extensions-* 2>/dev/null |
+              sed -e 's|-[0-9].*||' -e 's|.*/||')
+            if test -n "$packages"
+            then
+              pacman -R --noconfirm $packages
+            fi &&
+            for prefix in /mingw32 /mingw64 /clangarm64
+            do
+              if test -x $prefix/bin/gem
+              then
+                PATH=$prefix/bin:$PATH gem uninstall asciidoctor
+              fi
+            done
+          fi &&
+
           top_dir=$PWD &&
           cd "${{ matrix.directory }}" &&
           MAKEFLAGS=-j8 makepkg-mingw -s --noconfirm &&

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -74,7 +74,6 @@ sha256sums=('SKIP'
             '7413506c59d25621e475aa45447993748332c72cfbb4cf94cce6bee6f1218a09'
             '6d83e1cb1acdb6eb1f2d5cb9299298e57680f5ca43d43c3e67c9da17f21b9b01')
 
-USE_ASCIIDOCTOR="YesPlease"
 COMPAT_CFLAGS=
 STRIP=
 STRIP_OPTS=
@@ -96,13 +95,6 @@ then
   STRIP="${BASH_SOURCE%/*}/src/cv2pdb-strip"
 else
   options+=('strip')
-fi
-
-if test CLANGARM64 = "$MSYSTEM"
-then
-  # Asciidoctor depends on Ruby which is not available for CLANGARM64 yet
-  makedepends=("${makedepends[@]/${MINGW_PACKAGE_PREFIX}-asciidoctor}")
-  USE_ASCIIDOCTOR=
 fi
 
 pkgver() {
@@ -130,7 +122,7 @@ prepare () {
   cd "$srcdir/git" &&
 
   cat >config.mak <<-EOF
-USE_ASCIIDOCTOR = $USE_ASCIIDOCTOR
+USE_ASCIIDOCTOR = YesPlease
 COMPAT_CFLAGS += $COMPAT_CFLAGS
 LDFLAGS = $LDFLAGS
 EOF

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -17,7 +17,7 @@ license=('GPL2')
 
 options=()
 makedepends=('python' 'less' 'openssh' 'patch' 'make' 'tar' 'diffutils'
-	'ca-certificates' 'xmlto' "${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions")
+	'ca-certificates' 'xmlto' "${MINGW_PACKAGE_PREFIX}-asciidoctor")
 install=git.install
 
 case "$(printf "%s\n%s\n" "$pkgver" "2.18.0" | sort -V)" in
@@ -101,7 +101,7 @@ fi
 if test CLANGARM64 = "$MSYSTEM"
 then
   # Asciidoctor depends on Ruby which is not available for CLANGARM64 yet
-  makedepends=("${makedepends[@]/${MINGW_PACKAGE_PREFIX}-asciidoctor-extensions}")
+  makedepends=("${makedepends[@]/${MINGW_PACKAGE_PREFIX}-asciidoctor}")
   USE_ASCIIDOCTOR=
 fi
 


### PR DESCRIPTION
While enabling clangarm64 support on GfW's
`mingw-w64-asciidoctor-extensions` package, we realized that the
extensions are likely not needed anymore, because the Git project
added its own `Documentation/asciidoctor-extensions.rb` back in 2017.

Let's switch to the MSYS2-maintaned `mingw-w64-asciidoctor` instead,
so we don't have to maintain our own package anymore.

Ref: https://github.com/git-for-windows/MINGW-packages/pull/118
Ref: https://github.com/git/git/commit/55d2d812e49aece049b73682ad5980ea84e23839

Let's also enable arm64 support while we're at it.