### PR TITLE
mingw-w64-git: use /proc/cygdrive prefix in bin path when installing redirectors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,24 +59,6 @@ jobs:
           # reduce time required to install packages by disabling pacman's disk space checking
           sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf &&
 
-          # help git-sdk-arm64 switch from `asciidoc` to `asciidoctor`
-          if test mingw-w64-git = '${{ matrix.directory }}'
-          then
-            packages=$(ls -d /var/lib/pacman/local/mingw-w64-*-asciidoctor-extensions-* 2>/dev/null |
-              sed -e 's|-[0-9].*||' -e 's|.*/||')
-            if test -n "$packages"
-            then
-              pacman -R --noconfirm $packages
-            fi &&
-            for prefix in /mingw32 /mingw64 /clangarm64
-            do
-              if test -x $prefix/bin/gem
-              then
-                PATH=$prefix/bin:$PATH gem uninstall asciidoctor
-              fi
-            done
-          fi &&
-
           top_dir=$PWD &&
           cd "${{ matrix.directory }}" &&
           MAKEFLAGS=-j8 makepkg-mingw -s --noconfirm &&

--- a/mingw-w64-git/git.install
+++ b/mingw-w64-git/git.install
@@ -4,7 +4,7 @@ mingw_prefix_path () {
 }
 
 bin_path () {
-	echo "$(cygpath -am / | sed 's/^\([A-Z]\):/\/\1/')/bin"
+	echo "$(cygpath -am / | sed 's/^\([A-Z]\):/\/proc\/cygdrive\/\1/')/bin"
 }
 
 copy_files () {


### PR DESCRIPTION
Fix https://github.com/git-for-windows/git/issues/5067.