### PR TITLE
curl: Fix regression reading netrc

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,13 +35,17 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "pathtools.c"
         "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
-        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch")
+        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch"
+        "netrc-regression-1.patch::https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88.patch"
+        "netrc-regression-2.patch::https://github.com/curl/curl/commit/0cdde0fdfbeb8c35420f6d03fa4b77ed73497694.patch")
 sha256sums=('c95d5a1368803729345a632ce42cceeefd5f09c3b4d9582f858f6779f4b8b254'
             'SKIP'
             '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
             'd34c9474a0b54d36497e58b4792699ef37cc8b043a4cd5daf287e1e33f660207'
-            '418b5619b924d17ac71066323b5540d86d4e8055cabab925ece185770e9d1906')
+            '418b5619b924d17ac71066323b5540d86d4e8055cabab925ece185770e9d1906'
+            '708429a4e0b387dc9addc1f9166e07e5db22da42221887ddab9533c9e2bd1ca8'
+            'd817dd3746476bc513edd24a4f9a32674c3d5a04484bf80d894c1d2add67e8e2')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 if test -z "$WITHOUT_ALTERNATES"
@@ -91,7 +95,9 @@ prepare() {
 
   apply_patch_with_msg \
     0001-Make-cURL-relocatable.patch \
-    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
+    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch \
+    netrc-regression-1.patch \
+    netrc-regression-2.patch
 
   autoreconf -vfi
 }

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -90,6 +90,10 @@ prepare() {
     cmp "${startdir}/../mingw-w64-pathtools/pathtools.h" "${srcdir}/pathtools.h"
   } || exit 1
 
+  test ! -f "${srcdir}/netrc-regression-1.patch" ||
+  rm -f ${_realname}-${pkgver}/tests/data/test2309 \
+    ${_realname}-${pkgver}/tests/libtest/lib2309.c
+
   cd "${srcdir}/${_realname}-${pkgver}"
   cp -fHv "${srcdir}"/pathtools.[ch] lib/
 


### PR DESCRIPTION
See https://github.com/curl/curl/issues/15496
and https://github.com/curl/curl/issues/15513

Cherry-picked from 8b1c7bde2 (curl: Fix regression reading netrc, 2024-11-11) in msys2/MINGW-packages.

This is a companion to https://github.com/git-for-windows/MSYS2-packages/pull/199, even if the problem did not affect the MINGW variant of `curl` in my case ([I have no `.netrc`](https://github.com/curl/curl/issues/15496#issuecomment-2460427486), yet the MSYS variant _was_ affected).