### PR TITLE
Fix the cURL problem identified in `microsoft/git` via t5799.13(curl-connect: no server) failures

### DIFF
--- a/mingw-w64-curl/0003-ip-happy-do-not-set-unnecessary-timeout.patch
+++ b/mingw-w64-curl/0003-ip-happy-do-not-set-unnecessary-timeout.patch
@@ -1,0 +1,104 @@
+From 271add6fc90245bd99448357b4f5a76598eb3e85 Mon Sep 17 00:00:00 2001
+From: Stefan Eissing <stefan@eissing.org>
+Date: Mon, 29 Sep 2025 16:38:55 +0200
+Subject: [PATCH] ip-happy: do not set unnecessary timeout
+
+When attempts on all addresses have been started, do
+no longer set any EXPIRE_HAPPY_EYEBALLS timeouts.
+
+refs #18767
+---
+ lib/cf-ip-happy.c | 43 ++++++++++++++++++++++++++++++-------------
+ 1 file changed, 30 insertions(+), 13 deletions(-)
+
+diff --git a/lib/cf-ip-happy.c b/lib/cf-ip-happy.c
+index 0a1364e4b..801370fd9 100644
+--- a/lib/cf-ip-happy.c
++++ b/lib/cf-ip-happy.c
+@@ -156,6 +156,18 @@ static const struct Curl_addrinfo *cf_ai_iter_next(struct cf_ai_iter *iter)
+   return iter->last;
+ }
+ 
++static bool cf_ai_iter_has_more(struct cf_ai_iter *iter)
++{
++  const struct Curl_addrinfo *addr = iter->last ? iter->last->ai_next :
++    ((iter->n < 0) ? iter->head : NULL);
++  while(addr) {
++    if(addr->ai_family == iter->ai_family)
++      return TRUE;
++    addr = addr->ai_next;
++  }
++  return FALSE;
++}
++
+ #ifdef USE_IPV6
+ static bool cf_ai_iter_done(struct cf_ai_iter *iter)
+ {
+@@ -356,7 +368,7 @@ static CURLcode cf_ip_ballers_run(struct cf_ip_ballers *bs,
+ {
+   CURLcode result = CURLE_OK;
+   struct cf_ip_attempt *a = NULL, **panchor;
+-  bool do_more, more_possible;
++  bool do_more;
+   struct curltime now;
+   timediff_t next_expire_ms;
+   int i, inconclusive, ongoing;
+@@ -367,7 +379,6 @@ static CURLcode cf_ip_ballers_run(struct cf_ip_ballers *bs,
+ evaluate:
+   now = curlx_now();
+   ongoing = inconclusive = 0;
+-  more_possible = TRUE;
+ 
+   /* check if a running baller connects now */
+   i = -1;
+@@ -475,11 +486,8 @@ evaluate:
+       /* attempt timeout for restart has not expired yet */
+       goto out;
+     }
+-    else if(ongoing) {
++    else if(!ongoing) {
+       /* no more addresses, no inconclusive attempts */
+-      more_possible = FALSE;
+-    }
+-    else {
+       CURL_TRC_CF(data, cf, "no more attempts to try");
+       result = CURLE_COULDNT_CONNECT;
+       i = 0;
+@@ -493,21 +501,30 @@ evaluate:
+ 
+ out:
+   if(!result) {
++    bool more_possible;
++
+     /* when do we need to be called again? */
+     next_expire_ms = Curl_timeleft(data, &now, TRUE);
++    if(next_expire_ms <= 0) {
++      failf(data, "Connection timeout after %" FMT_OFF_T " ms",
++            curlx_timediff(now, data->progress.t_startsingle));
++      return CURLE_OPERATION_TIMEDOUT;
++    }
++
++    more_possible = cf_ai_iter_has_more(&bs->addr_iter);
++#ifdef USE_IPV6
++    if(!more_possible)
++      more_possible = cf_ai_iter_has_more(&bs->ipv6_iter);
++#endif
+     if(more_possible) {
+       timediff_t expire_ms, elapsed_ms;
+       elapsed_ms = curlx_timediff(now, bs->last_attempt_started);
+       expire_ms = CURLMAX(bs->attempt_delay_ms - elapsed_ms, 0);
+       next_expire_ms = CURLMIN(next_expire_ms, expire_ms);
++      CURL_TRC_CF(data, cf, "next HAPPY_EYBALLS timeout in %" FMT_TIMEDIFF_T
++                  "ms", next_expire_ms);
++      Curl_expire(data, next_expire_ms, EXPIRE_HAPPY_EYEBALLS);
+     }
+-
+-    if(next_expire_ms <= 0) {
+-      failf(data, "Connection timeout after %" FMT_OFF_T " ms",
+-            curlx_timediff(now, data->progress.t_startsingle));
+-      return CURLE_OPERATION_TIMEDOUT;
+-    }
+-    Curl_expire(data, next_expire_ms, EXPIRE_HAPPY_EYEBALLS);
+   }
+   return result;
+ }

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.16.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,13 +35,15 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "pathtools.c"
         "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
-        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch")
+        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch"
+        "0003-ip-happy-do-not-set-unnecessary-timeout.patch")
 sha256sums=('9459180ab4933b30d0778ddd71c91fe2911fab731c46e59b3f4c8385b1596c91'
             'SKIP'
             '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
             '8aa4eab2f2c38afb0ae7825be5be032194574f08cedd37b57b9ea5a19eb25ad4'
-            'c43eb97757f71a5f2368fa1b132d286e8ceb91060742e643d4dbc06712a57e94')
+            'c43eb97757f71a5f2368fa1b132d286e8ceb91060742e643d4dbc06712a57e94'
+            '90de3265dc33894fe53fb2b0c0ffd25e1fae0330d2a5e00ebafb3cb34c2e7591')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 if test -z "$WITHOUT_ALTERNATES"
@@ -91,7 +93,8 @@ prepare() {
 
   apply_patch_with_msg \
     0001-Make-cURL-relocatable.patch \
-    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
+    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch \
+    0003-ip-happy-do-not-set-unnecessary-timeout.patch
 
   autoreconf -vfi
 }


### PR DESCRIPTION
In cURL v8.16.0, the behavior changed subtly: Timeouts were added even in circumstances where cURL failed to connect and should have errored out with the corresponding `CURLE_COULDNT_CONNECT` instead.

This has been identified [in `microsoft/git`](https://github.com/microsoft/git/pull/799#issuecomment-3346304034) via test failures in t5799:

```
 ++ test_when_finished per_test_cleanup
  ++ test 0 = 0
  ++ test_cleanup='{ per_test_cleanup
  		} && (exit "$eval_ret"); eval_ret=$?; :'
  ++ test_must_fail git -C 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/repo_t1' gvfs-helper --cache-server=disable --remote=origin get --max-retries=2
  ++ case "$1" in
  ++ _test_ok=
  ++ test_must_fail_acceptable git -C 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/repo_t1' gvfs-helper --cache-server=disable --remote=origin get --max-retries=2
  ++ test git = env
  ++ test git = nongit
  ++ case "$1" in
  ++ return 0
  ++ git -C 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/repo_t1' gvfs-helper --cache-server=disable --remote=origin get --max-retries=2
  ++ exit_code=2
  ++ test 2 -eq 0
  ++ test_match_signal 13 2
  ++ test 2 = 141
  ++ test 2 = 269
  ++ return 1
  ++ test 2 -gt 129
  ++ test 2 -eq 127
  ++ test 2 -eq 126
  ++ return 0
  ++ grep -q 'error: get: (curl:7)' OUT.stderr
  error: last command exited with $?=1
  ++ per_test_cleanup
  ++ stop_gvfs_protocol_server
  ++ test -f 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/pid-file.pid'
  ++ return 0
  ++ rm -rf 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/shared_cache_t1/[0-9a-f][0-9a-f]/'
  ++ rm -rf 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/shared_cache_t1/info/*'
  ++ rm -rf 'D:/a/git/git/t/trash directory.t5799-gvfs-helper/shared_cache_t1/pack/tempPacks'
  ++ rm -rf OUT.output OUT.stderr
  ++ return 0
  ++ exit 1
  ++ eval_ret=1
  ++ :
  not ok 13 - curl-error: no server
```

It is a bit difficult to diagnose the problem from Git's output, as the interesting information is suppressed: Instead of `curl:7` (`CURLE_COULDNT_CONNECT`), it reports `curl:28` (`CURLE_OPERATION_TIMEDOUT`). I reported this to the cURL project and they gracefully jumped on fixing it. This here PR back-ports the fix from https://github.com/curl/curl/pull/18768.