### PR TITLE
git: drop `git svn` from the `git-for-windows-addons`

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -541,7 +541,6 @@ package_git-for-windows-addons () {
     "${MINGW_PACKAGE_PREFIX}-${_realname}-subtree"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-credential-wincred"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-send-email"
-    "${MINGW_PACKAGE_PREFIX}-${_realname}-svn"
     "${MINGW_PACKAGE_PREFIX}-gitk"
     "${MINGW_PACKAGE_PREFIX}-${_realname}-gui")
   pkgdesc="Git for Windows extra executables and wrappers (mingw-w64)"


### PR DESCRIPTION
As per https://github.com/git-for-windows/git/issues/5405, the Git for Windows project no longer includes `git svn` in the published installers and portable Git packages.

Dropping this dependency makes it so.