### PR TITLE
git: sync with MSYS2

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -24,6 +24,11 @@ pkgdesc="The fast distributed version control system (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
 url="https://gitforwindows.org/"
+msys2_references=(
+  "cpe: cpe:/a:git-scm:git"
+  "cpe: cpe:/a:git:git"
+  "cpe: cpe:/a:git_project:git"
+)
 license=('GPL2')
 
 options=()

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -102,6 +102,7 @@ else
 fi
 
 SHAREDIR=$MINGW_PREFIX/share/git
+_DEFAULT_EDITOR=nano
 
 prepare () {
   cd "$srcdir/git" &&
@@ -111,6 +112,7 @@ prepare () {
 	USE_ASCIIDOCTOR = YesPlease
 	COMPAT_CFLAGS += $COMPAT_CFLAGS
 	LDFLAGS = $LDFLAGS
+	DEFAULT_EDITOR = $_DEFAULT_EDITOR
 	EOF
 
   cp ../git-bash.adoc Documentation/
@@ -174,7 +176,8 @@ package_git () {
            "${MINGW_PACKAGE_PREFIX}-ca-certificates"
            "${MINGW_PACKAGE_PREFIX}-expat>=2.0"
            "${MINGW_PACKAGE_PREFIX}-openssl"
-           "${MINGW_PACKAGE_PREFIX}-pcre2")
+           "${MINGW_PACKAGE_PREFIX}-pcre2"
+           "$_DEFAULT_EDITOR")
 
   cd "$srcdir"/git
 

--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -102,7 +102,7 @@ else
 fi
 
 SHAREDIR=$MINGW_PREFIX/share/git
-_DEFAULT_EDITOR=nano
+_DEFAULT_EDITOR="${_DEFAULT_EDITOR:-nano}"
 
 prepare () {
   cd "$srcdir/git" &&


### PR DESCRIPTION
There have been a couple of edits in upstream MSYS2 which we need to integrate into Git for Windows' fork, lest the next Git for Windows version sync will overwrite those edits.

This change requires https://github.com/git-for-windows/build-extra/pull/685 to be merged first.