### PR TITLE
curl(schannel): increase renegotiation timeout to 60 seconds

### DIFF
--- a/mingw-w64-curl/70bb0db76720c152f6a55bbe12cf162b55cb105b.patch
+++ b/mingw-w64-curl/70bb0db76720c152f6a55bbe12cf162b55cb105b.patch
@@ -1,0 +1,36 @@
+From 70bb0db76720c152f6a55bbe12cf162b55cb105b Mon Sep 17 00:00:00 2001
+From: Jay Satiro <raysatiro@yahoo.com>
+Date: Fri, 10 Apr 2026 14:02:55 -0400
+Subject: [PATCH] schannel: increase renegotiation timeout to 60 seconds
+
+Prior to this change the timeout was 7 seconds but that is too short for
+enhanced-security users that have to fill out an interactive prompt on
+Schannel renegotiation (PIN, smart card, etc).
+
+Reported-by: Tim Omta
+
+Fixes https://github.com/curl/curl/issues/21270
+Closes https://github.com/curl/curl/pull/21291
+---
+ lib/vtls/schannel.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/lib/vtls/schannel.c b/lib/vtls/schannel.c
+index a2b76da98200..7bfbbcf04c85 100644
+--- a/lib/vtls/schannel.c
++++ b/lib/vtls/schannel.c
+@@ -1757,7 +1757,13 @@ enum schannel_renegotiate_caller_t {
+   SCH_RENEG_CALLER_IS_SEND
+ };
+ 
+-#define MAX_RENEG_BLOCK_TIME (7 * 1000) /* 7 seconds in milliseconds */
++/* The maximum time we allow for Schannel renegotiation which may in some
++   rare cases block either due to libcurl (waiting on the socket) or Windows
++   (waiting on an interactive security prompt). Note Schannel "renegotiation"
++   is not necessarily literal TLS renegotiation, but means DecryptMessage
++   returned SEC_I_RENEGOTIATE which means at least the security context needs
++   to be re-established. */
++#define MAX_RENEG_BLOCK_TIME (60 * 1000) /* 60 seconds in milliseconds */
+ 
+ /* This function renegotiates the connection due to a server request received
+    by schannel_recv. This function returns CURLE_AGAIN if the renegotiation is

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-winssl")
 pkgver=8.19.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -35,13 +35,15 @@ source=("https://github.com/curl/curl/releases/download/${_realname}-${pkgver//.
         "pathtools.c"
         "pathtools.h"
         "0001-Make-cURL-relocatable.patch"
-        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch")
+        "0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch"
+        "70bb0db76720c152f6a55bbe12cf162b55cb105b.patch")
 sha256sums=('eba3230c1b659211a7afa0fbf475978cbf99c412e4d72d9aa92d020c460742d4'
             'SKIP'
             '08209cbf1633fa92eae7e5d28f95f8df9d6184cc20fa878c99aec4709bb257fd'
             '965d3921ec4fdeec94a2718bc2c85ce5e1a00ea0e499330a554074a7ae15dfc6'
             'bb03c858d9322d005c414b2b6713200eb82df32ee00fb7507ed9896c026aab2a'
-            '089a62a2e389c70dd40c5fdf80ee69d46f083b105101123b9f5a07dc24411bb4')
+            '089a62a2e389c70dd40c5fdf80ee69d46f083b105101123b9f5a07dc24411bb4'
+            'ffaadb16a5f1aaa4e0a33473b905a6650e6291afecb39f56805eaffc26a20932')
 validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2')  # Daniel Stenberg
 
 if test -z "$WITHOUT_ALTERNATES"
@@ -91,7 +93,8 @@ prepare() {
 
   apply_patch_with_msg \
     0001-Make-cURL-relocatable.patch \
-    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch
+    0002-Hack-make-relocation-work-inside-libexec-git-core-an.patch \
+    70bb0db76720c152f6a55bbe12cf162b55cb105b.patch
 
   autoreconf -vfi
 }


### PR DESCRIPTION
As reported by Tim Omta in https://github.com/curl/curl/issues/21270, the renegotiation timeout of 7 seconds caused serious problems in some scenarios, and was already increased to 60 seconds in cURL's main branch, in time for their v8.20.0 release on April 29th.

Unfortunately, this is too late for the patch to make it into Git for Windows v2.54.0, which is currently scheduled for April 20th (see https://gh.io/gitCal for details).

So let's backport the patch.