### PR TITLE
git: include the Rust parts by default

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -83,6 +83,11 @@ STRIP=
 STRIP_OPTS=
 LDFLAGS=
 
+if test -z "$NO_RUST"
+then
+  makedepends+=("${MINGW_PACKAGE_PREFIX}-rust")
+fi
+
 if test -z "$WITH_PDBS"
 then
   options+=('strip')


### PR DESCRIPTION
As of Git v2.55, there are (opt-out) parts written in Rust. Git for Windows still supports Windows 8.1 and therefore cannot easily use those (they would cause `git.exe` to fail to work on that Windows version), and therefore it has to build with NO_RUST for now. The regular `mingw-w64-git` package in MSYS2 (which already dropped support for Windows 8.1) should of course build _with_ the Rust bits.