### PR TITLE
git: skip Rust bits in i686 builds

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -83,6 +83,12 @@ STRIP=
 STRIP_OPTS=
 LDFLAGS=
 
+if test i686 = "$CARCH"
+then
+  # There is no i686 Rust we can use
+  export NO_RUST=ThatsRight
+fi
+
 if test -z "$NO_RUST"
 then
   makedepends+=("${MINGW_PACKAGE_PREFIX}-rust")


### PR DESCRIPTION
Git for Windows builds the mingw-w64-git package with NO_RUST by default. But MSYS2 doesn't, hence the need for this change.

With this PR, the `mingw-w64-git/` directory is treesame between msys2 and git-for-windows once again.