### PR TITLE
git: restore full PDB generation

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -107,7 +107,7 @@ then
 else
   pkgname+=("${MINGW_PACKAGE_PREFIX}-${_realname}-pdb")
   makedepends+=("${MINGW_PACKAGE_PREFIX}-cv2pdb")
-  options+=('!strip')
+  options+=('debug !strip')
   COMPAT_CFLAGS="-gdwarf-4 -gstrict-dwarf" # cv2pdb cannot really handle DWARF5 yet
   STRIP="${BASH_SOURCE%/*}/src/cv2pdb-strip"
 fi


### PR DESCRIPTION
The git-artifacts runs currently fail in the SDKs, e.g. https://github.com/git-for-windows/git-sdk-32/actions/runs/33850014448/job/100950448975#step:9:1964 The symptom is:

  contrib/credential/wincred/git-credential-wincred.exe: no codeview debug entries found

The reason for this is that Git itself is compiled without -g. The older CRT startup objects happened to contain DWARF because the CRT recipe disabled makepkg buildflags and Autoconf chose -g -O2. That accidental DWARF described uninteresting CRT startup functions, not Git's functions. Therefore, the generated PDB files lacked Git function debug information even when local packaging appeared to succeed.

In https://github.com/msys2/MINGW-packages/commit/328e5e20f7 (crt: enable buildflags (#31309), 2026-09-01), MSYS2 enabled makepkg buildflags when building the CRT. Since the global makepkg configuration has !debug, the new CRT startup objects no longer supplied incidental DWARF, exposing the latent `mingw-w64-git` packaging bug.

Fix this by making the cv2pdb build request debug information explicitly.