### PR TITLE
git(with pdbs): ensure that `wincred` has debug information

### DIFF
--- a/mingw-w64-git/PKGBUILD
+++ b/mingw-w64-git/PKGBUILD
@@ -153,7 +153,7 @@ build() {
   # stripped.
   export PATH="$MINGW_PREFIX/bin:$PATH"
   make -C contrib/credential/wincred clean &&
-  make -C contrib/credential/wincred &&
+  make -C contrib/credential/wincred CFLAGS="$CFLAGS $COMPAT_CFLAGS" &&
 
   targets= &&
   case "${pkgname[@]}" in ''|*-git|*-git\ *) targets="$targets all";; esac &&


### PR DESCRIPTION
In https://github.com/git-for-windows/MINGW-packages/pull/216, I tried to fix the regression where building the `mingw-w64-git` package failed in the step that should produce `.pdb` files. This PR fixed most of it, but not all of it: The `CFLAGS` do not include `-g` and the Makefile of `contrib/credential/wincred` does not add that option by default.

So let's append the `COMPAT_CFLAGS` explicitly, as they specifically get the correct `-g` flags added when `.pdb` files should be produced via cv2pdb.